### PR TITLE
Uses configured network for sendTx

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastnear-js-monorepo",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Easily interact with the NEAR Protocol blockchain",
   "scripts": {
     "type-check": "yarn workspaces foreach --all -t run type-check",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/api",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Interact with NEAR Protocol blockchain including transaction signing, utilities, and more.",
   "type": "module",
   "types": "./dist/esm/index.d.ts",

--- a/packages/api/src/state.ts
+++ b/packages/api/src/state.ts
@@ -91,7 +91,7 @@ export const getWalletAdapterState = (): WalletAdapterState => {
     publicKey: _state.publicKey,
     accountId: _state.accountId,
     lastWalletId: _state.lastWalletId,
-    networkId: DEFAULT_NETWORK_ID,
+    networkId: _config.networkId,
   };
 }
 

--- a/packages/borsh-schema/package.json
+++ b/packages/borsh-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/borsh-schema",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "NEAR Protocol's borsh schema for common applications",
   "type": "module",
   "types": "./dist/esm/index.d.ts",

--- a/packages/repl/package.json
+++ b/packages/repl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/repl",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "license": "MIT",
   "description": "Simple REPL to explore NEAR blockchain objects",
   "bin": "bin/repl.cjs",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/utils",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Utility functions for interactions with the NEAR blockchain",
   "type": "module",
   "types": "./dist/esm/index.d.ts",

--- a/packages/wallet-adapter-widget/package.json
+++ b/packages/wallet-adapter-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/wallet-adapter-widget",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "User interfaces for select NEAR Protocol web3 wallets",
   "type": "module",
   "types": "./dist/esm/index.d.ts",

--- a/packages/wallet-adapter/package.json
+++ b/packages/wallet-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/wallet-adapter",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Optimized interfaces for a NEAR Protocol wallet adapter",
   "type": "module",
   "types": "./dist/esm/index.d.ts",


### PR DESCRIPTION
I noticed that sendTx always redirects to mainnet wallet for signing; this uses the configured network