### PR TITLE
0.9.7: Fix fromBase64 to return bytes during mapAction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastnear-js-monorepo",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Easily interact with the NEAR Protocol blockchain",
   "scripts": {
     "type-check": "yarn workspaces foreach --all -t run type-check",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/api",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Interact with NEAR Protocol blockchain including transaction signing, utilities, and more.",
   "type": "module",
   "types": "./dist/esm/index.d.ts",

--- a/packages/borsh-schema/package.json
+++ b/packages/borsh-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/borsh-schema",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "NEAR Protocol's borsh schema for common applications",
   "type": "module",
   "types": "./dist/esm/index.d.ts",

--- a/packages/repl/package.json
+++ b/packages/repl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/repl",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "license": "MIT",
   "description": "Simple REPL to explore NEAR blockchain objects",
   "bin": "bin/repl.cjs",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/utils",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Utility functions for interactions with the NEAR blockchain",
   "type": "module",
   "types": "./dist/esm/index.d.ts",

--- a/packages/utils/src/transaction.ts
+++ b/packages/utils/src/transaction.ts
@@ -1,6 +1,6 @@
 import { serialize as borshSerialize, deserialize as borshDeserialize, Schema } from "borsh";
 import { keyFromString } from "./crypto.js";
-import { fromBase58, fromBase64, toBase64 } from "./misc.js";
+import {base64ToBytes, fromBase58, fromBase64, toBase64} from "./misc.js";
 import { getBorshSchema } from "@fastnear/borsh-schema";
 
 export interface PlainTransaction {
@@ -86,7 +86,7 @@ export function mapAction(action: any): object {
     case "DeployContract": {
       return {
         deployContract: {
-          code: fromBase64(action.codeBase64),
+          code: base64ToBytes(action.codeBase64),
         },
       };
     }
@@ -95,7 +95,7 @@ export function mapAction(action: any): object {
         functionCall: {
           methodName: action.methodName,
           args: (action.argsBase64 !== null && action.argsBase64 !== undefined) ?
-            fromBase64(action.argsBase64) :
+            base64ToBytes(action.argsBase64) :
             (new TextEncoder().encode(JSON.stringify(action.args))),
           gas: BigInt(action.gas ?? "300000000000000"),
           deposit: BigInt(action.deposit ?? "0"),

--- a/packages/wallet-adapter-widget/package.json
+++ b/packages/wallet-adapter-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/wallet-adapter-widget",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "User interfaces for select NEAR Protocol web3 wallets",
   "type": "module",
   "types": "./dist/esm/index.d.ts",

--- a/packages/wallet-adapter/package.json
+++ b/packages/wallet-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/wallet-adapter",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Optimized interfaces for a NEAR Protocol wallet adapter",
   "type": "module",
   "types": "./dist/esm/index.d.ts",


### PR DESCRIPTION
- For some reason `fromBase64` returned string, but we expect bytes in the borsh