### PR TITLE
Exposes sign delegate action in wallet

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -212,6 +212,7 @@ Indexed key-value history for exact keys, predecessor scans, and account-scoped 
 - `nearWallet.connect` / `disconnect` / `restore`: open, close, or rehydrate a session per network. `connect({ network, contractId, manifest })` is the canonical entrypoint; `contractId` mints a function-call key scoped to that contract so zero-deposit calls sign silently.
 - `nearWallet.sendTransaction({ receiverId, actions, network })` / `sendTransactions`: dispatch one or many transactions through the connected wallet on the chosen network.
 - `nearWallet.signMessage({ message, recipient, nonce, network })`: NEP-413 message signing.
+- `nearWallet.signDelegateActions({ delegateActions, signerId?, network? })`: sign NEP-366 delegate actions for gasless relay-based flows. Returns `{ signedDelegateActions: Array<{ delegateHash: Uint8Array; signedDelegate: SignedDelegate }> }`.
 - `nearWallet.addFunctionCallKey({ contractId, methodNames, allowance, network })` (`@fastnear/wallet@1.1.4+`): grant a second function-call key on another contract after sign-in, so a follow-on zero-deposit call to that contract also signs silently.
 - `nearWallet.accountId` / `isConnected` / `connectedNetworks` / `switchNetwork`: per-network session inspection and the active-network cursor.
 - `nearWallet.onConnect` / `onDisconnect`: subscribe to session lifecycle.

--- a/llms.txt
+++ b/llms.txt
@@ -36,6 +36,7 @@ Wallet runtime surfaces (@fastnear/wallet):
 - nearWallet.sendTransaction({ receiverId, actions, network })
 - nearWallet.sendTransactions({ transactions, network })
 - nearWallet.signMessage({ message, recipient, nonce, network })
+- nearWallet.signDelegateActions({ delegateActions, signerId, network })
 - nearWallet.addFunctionCallKey({ contractId, methodNames, allowance, network })
 - nearWallet.accountId({ network })
 - nearWallet.isConnected({ network })

--- a/packages/wallet/src/connector.ts
+++ b/packages/wallet/src/connector.ts
@@ -4,10 +4,22 @@ import {
   type SignAndSendTransactionParams,
   type SignAndSendTransactionsParams,
   type SignMessageParams,
+  type SignDelegateActionsParams,
   type ConnectorAction,
   type WalletManifest,
 } from "@fastnear/near-connect";
 export type { WalletManifest };
+
+export type { SignDelegateActionsParams } from "@fastnear/near-connect";
+
+export interface SignDelegateActionResult {
+  delegateHash: Uint8Array;
+  signedDelegate: any;
+}
+
+export interface SignDelegateActionsResponse {
+  signedDelegateActions: SignDelegateActionResult[];
+}
 
 type Network = "mainnet" | "testnet";
 
@@ -439,6 +451,31 @@ export async function signMessage(params: SignMessageParams & { network?: Networ
     throw new Error(`No wallet connected on ${network}. Call connect({ network: "${network}" }) first.`);
   }
   return state.connectedWallet.signMessage({ ...params, network });
+}
+
+/**
+ * Sign delegate actions (NEP-366) via the connected wallet.
+ * Accepts both fastnear-style flat actions and ConnectorActions.
+ */
+export async function signDelegateActions(
+  params: SignDelegateActionsParams & { network?: Network }
+): Promise<SignDelegateActionsResponse> {
+  const network = params.network ?? activeNetwork;
+  const state = networkStates[network];
+  if (!state.connectedWallet) {
+    throw new Error(`No wallet connected on ${network}. Call connect({ network: "${network}" }) first.`);
+  }
+  const delegateActions = params.delegateActions.map((da: any) => ({
+    receiverId: da.receiverId,
+    actions: da.actions.some(isFastnearAction)
+      ? toConnectorActions(da.actions)
+      : da.actions,
+  }));
+  return state.connectedWallet.signDelegateActions({
+    delegateActions,
+    signerId: params.signerId ?? state.currentAccountId ?? undefined,
+    network,
+  });
 }
 
 /**

--- a/packages/wallet/src/connector.ts
+++ b/packages/wallet/src/connector.ts
@@ -465,7 +465,7 @@ export async function signDelegateActions(
   if (!state.connectedWallet) {
     throw new Error(`No wallet connected on ${network}. Call connect({ network: "${network}" }) first.`);
   }
-  const delegateActions = params.delegateActions.map((da: any) => ({
+  const delegateActions = params.delegateActions.map((da) => ({
     receiverId: da.receiverId,
     actions: da.actions.some(isFastnearAction)
       ? toConnectorActions(da.actions)

--- a/packages/wallet/src/index.ts
+++ b/packages/wallet/src/index.ts
@@ -17,6 +17,7 @@ export {
   removeDebugWallet,
   switchNetwork,
   addFunctionCallKey,
+  signDelegateActions
 } from "./connector";
 
-export type { ConnectOptions, ConnectResult, WalletManifest } from "./connector";
+export type { ConnectOptions, ConnectResult, WalletManifest, SignDelegateActionsParams, SignDelegateActionsResponse } from "./connector";

--- a/recipes/index.json
+++ b/recipes/index.json
@@ -963,7 +963,8 @@
       "relatedRecipes": [
         "function-call",
         "transfer",
-        "sign-message"
+        "sign-message",
+        "sign-delegate-actions"
       ]
     },
     {
@@ -1177,7 +1178,88 @@
         "filtersMustStayStable": false
       },
       "relatedRecipes": [
-        "connect-wallet"
+        "connect-wallet",
+        "sign-delegate-actions"
+      ]
+    },
+    {
+      "id": "sign-delegate-actions",
+      "title": "How do I sign delegate actions for gasless transactions?",
+      "summary": "Sign NEP-366 delegate actions via the connected wallet so a relayer can submit them on-chain without the user paying gas.",
+      "network": "mainnet",
+      "auth": "wallet",
+      "api": "nearWallet.signDelegateActions",
+      "example": {
+        "delegateActions": [
+          {
+            "receiverId": "berryclub.ek.near",
+            "actions": [
+              {
+                "type": "FunctionCall",
+                "methodName": "draw",
+                "args": { "pixels": [{ "x": 10, "y": 20, "color": 65280 }] },
+                "gas": "30000000000000",
+                "deposit": "0"
+              }
+            ]
+          }
+        ]
+      },
+      "snippets": [
+        {
+          "id": "terminal",
+          "label": "Terminal",
+          "environment": "terminal",
+          "language": "bash",
+          "runnable": false,
+          "reason": "browser_required",
+          "code": "# Browser wallet required.\n# Signing delegate actions depends on a connected wallet provider.\n# Use the browser-global or ESM snippet for this task."
+        },
+        {
+          "id": "browser-global",
+          "label": "Browser Global",
+          "environment": "browserGlobal",
+          "language": "js",
+          "runnable": true,
+          "code": "const result = await nearWallet.signDelegateActions({\n  delegateActions: [\n    {\n      receiverId: \"berryclub.ek.near\",\n      actions: [\n        {\n          type: \"FunctionCall\",\n          methodName: \"draw\",\n          args: { pixels: [{ x: 10, y: 20, color: 65280 }] },\n          gas: \"30000000000000\",\n          deposit: \"0\",\n        },\n      ],\n    },\n  ],\n});\n\nnear.print({\n  count: result.signedDelegateActions.length,\n  first_delegate_hash: result.signedDelegateActions[0]?.delegateHash,\n});"
+        },
+        {
+          "id": "esm",
+          "label": "ESM",
+          "environment": "esm",
+          "language": "js",
+          "runnable": true,
+          "code": "import * as nearWallet from \"@fastnear/wallet\";\n\nawait nearWallet.restore({\n  network: \"mainnet\",\n  contractId: \"berryclub.ek.near\",\n  manifest: \"./manifest.json\",\n});\n\nconst result = await nearWallet.signDelegateActions({\n  delegateActions: [\n    {\n      receiverId: \"berryclub.ek.near\",\n      actions: [\n        {\n          type: \"FunctionCall\",\n          methodName: \"draw\",\n          args: { pixels: [{ x: 10, y: 20, color: 65280 }] },\n          gas: \"30000000000000\",\n          deposit: \"0\",\n        },\n      ],\n    },\n  ],\n});\n\nnear.print({\n  count: result.signedDelegateActions.length,\n  first_delegate_hash: result.signedDelegateActions[0]?.delegateHash,\n});"
+        }
+      ],
+      "service": "wallet",
+      "returns": "SignDelegateActionsResponse",
+      "outputKeys": [
+        "signedDelegateActions[].delegateHash",
+        "signedDelegateActions[].signedDelegate"
+      ],
+      "responseNotes": [
+        "Returns signed delegate actions that a relayer can submit on-chain, enabling gasless transactions for the user.",
+        "The wallet must support the signDelegateActions feature (check WalletFeatures.signDelegateActions)."
+      ],
+      "chooseWhen": [
+        "Choose this when building gasless or relay-based flows where a third party submits the transaction on the user's behalf.",
+        "Prefer sign-message when you only need an off-chain signature, or function-call when the user can pay gas directly."
+      ],
+      "followUps": [
+        "Submit the signed delegate actions through a relayer service to execute on-chain without the signer paying gas.",
+        "If the flow does not need a relayer, use near.recipes.functionCall for a standard wallet-signed transaction instead."
+      ],
+      "pagination": {
+        "kind": "none",
+        "requestFields": [],
+        "responseFields": [],
+        "filtersMustStayStable": false
+      },
+      "relatedRecipes": [
+        "connect-wallet",
+        "sign-message",
+        "function-call"
       ]
     },
     {


### PR DESCRIPTION
## Add `signDelegateActions` as a top-level export

### Problem

`signDelegateActions` is fully implemented on all wallet adapters (`ParentFrameWallet`, `InjectedWallet`, `SandboxedWallet`) in `@fastnear/near-connect`, but `@fastnear/wallet` does not expose it. The internal `connectedWallet` variable is a module-scoped closure — not reachable from outside — so consumers cannot call `signDelegateActions` at all.

This blocks any dApp that needs meta-transactions (NEP-366 / delegate actions), which is the standard pattern for gasless relay-based flows.

### Current state

The method exists on every adapter and is feature-flagged in `WalletFeatures`:

```ts
// @fastnear/near-connect types/index.d.ts
signDelegateActions(params: SignDelegateActionsParams): Promise<<SignDelegateActionsResponse>;

// WalletFeatures
signDelegateActions: boolean;
```

But `@fastnear/wallet` only exports:

```
accountId, availableWallets, connect, disconnect, isConnected,
onConnect, onDisconnect, registerDebugWallet, removeDebugWallet,
reset, restore, selectWallet, sendTransaction, sendTransactions,
signMessage, switchNetwork, walletName
```

The `connectedWallet` variable inside `connector.js` is a `let`-scoped closure, not a property on the module exports, so `(walletModule as any)._connectedWallet` returns `undefined` at runtime.

### Proposed change

Add `signDelegateActions` following the same pattern as existing `signMessage`/`sendTransaction`:

**`connector.js`**:
```js
export async function signDelegateActions(params) {
  if (!connectedWallet) {
    throw new Error("No wallet connected");
  }
  return connectedWallet.signDelegateActions(params);
}
```

**`index.d.ts`**:
```ts
export function signDelegateActions(params: SignDelegateActionsParams): Promise<<SignDelegateActionsResponse>;

// Re-export the types from @fastnear/near-connect
export { type SignDelegateActionsParams, type SignDelegateActionsResponse } from "@fastnear/near-connect";
```

### Expected return type

From `@fastnear/near-connect`:

```ts
interface SignDelegateActionsParams {
  network?: Network;
  signerId?: string;
  delegateActions: Array<{
    actions: Array<Action | ConnectorAction>;
    receiverId: string;
  }>;
}

type SignDelegateActionsResponse = {
  signedDelegateActions: SignDelegateActionResult[];
};

type SignDelegateActionResult = {
  delegateHash: Uint8Array;
  signedDelegate: SignedDelegate;  // from @near-js/transactions
};
```

### Use case

Sign in with NEAR (SIWN) authentication plugins need `signDelegateActions` to construct signed delegate actions that a relayer can submit on-chain, enabling gasless transactions for users. This is the core primitive for NEP-366 meta-transactions.