### PR TITLE
Add signMessageParams passthrough to connect() — enable single-popup sign-in + message signing

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1596,6 +1596,101 @@ near.print({
 });
 ```
 
+## How do I connect a wallet and sign a message in one step?
+
+- ID: `connect-and-sign-message`
+- API: `near.recipes.connect`
+- Service: `wallet`
+- Returns: `{ accountId: string; publicKey?: string; signedMessage?: SignedMessage }`
+- Network: `mainnet`
+- Auth: `wallet`
+- Summary: Combine sign-in and NEP-413 message signing into a single wallet popup instead of two.
+- Output keys: `accountId`, `publicKey`, `signedMessage`
+- Pagination: none; request fields: none; response fields: none; filters must stay stable: no
+
+Choose this when:
+
+- Choose this when you want sign-in and message signing in a single user interaction.
+- Prefer this over separate connect + signMessage calls when the wallet supports signInAndSignMessage.
+
+Response notes:
+
+- When signMessageParams is provided, the connector filters the wallet picker to only show wallets with the signInAndSignMessage feature flag.
+- The signedMessage field contains the NEP-413 signature result, avoiding a second popup.
+
+Follow-ups:
+
+- If the wallet doesn't support signInAndSignMessage, fall back to separate near.recipes.connect and near.recipes.signMessage calls.
+- After connecting and signing, send one contract action with near.recipes.functionCall.
+
+Related recipes:
+
+- `connect-wallet`
+- `sign-message`
+- `function-call`
+
+Example inputs:
+
+```json
+{
+  "contractId": "berryclub.ek.near",
+  "signMessageParams": {
+    "message": "Sign in to myapp.near",
+    "recipient": "myapp.near",
+    "nonce": "(32-byte Uint8Array)"
+  }
+}
+```
+
+### Terminal
+
+```bash
+# Browser wallet required.
+# Connecting and signing a message needs a browser environment with a wallet.
+# Use the browser-global or ESM snippet for this task.
+```
+
+### Browser Global
+
+```js
+const result = await near.recipes.connect({
+  contractId: "berryclub.ek.near",
+  signMessageParams: {
+    message: "Sign in to FastNear Berry Club",
+    recipient: window.location.host,
+    nonce: crypto.getRandomValues(new Uint8Array(32)),
+  },
+});
+
+near.print(result);
+```
+
+### ESM
+
+```js
+import * as near from "@fastnear/api";
+import * as nearWallet from "@fastnear/wallet";
+
+near.config({ apiKey: process.env.FASTNEAR_API_KEY || undefined });
+near.useWallet(nearWallet);
+await nearWallet.restore({
+  network: "mainnet",
+  contractId: "berryclub.ek.near",
+  manifest: "./manifest.json",
+});
+
+const result = await near.recipes.connect({
+  contractId: "berryclub.ek.near",
+  signMessageParams: {
+    message: "Sign in to FastNear Berry Club",
+    recipient: window.location.host,
+    nonce: crypto.getRandomValues(new Uint8Array(32)),
+  },
+});
+
+near.print(result);
+```
+
 ## What is this account's FT balance?
 
 - ID: `ft-balance`

--- a/llms.txt
+++ b/llms.txt
@@ -104,6 +104,7 @@ Recipe index:
 - transfer: How do I transfer NEAR? (wallet, WalletTransactionResult, wallet+deposit, mainnet)
 - sign-message: How do I sign a message? (wallet, WalletMessageSignatureResult, wallet, mainnet)
 - sign-delegate-actions: How do I sign delegate actions for gasless transactions? (wallet, SignDelegateActionsResponse, wallet, mainnet)
+- connect-and-sign-message: How do I connect a wallet and sign a message in one step? (wallet, { accountId: string; publicKey?: string; signedMessage?: SignedMessage }, wallet, mainnet)
 - ft-balance: What is this account's FT balance? (rpc, string, none, mainnet)
 - ft-metadata: What does this NEP-141 token call itself? (rpc, { name: string; symbol: string; decimals: number; icon?: string; reference?: string; reference_hash?: string }, none, mainnet)
 - ft-inventory: Which fungible tokens does this account hold? (api, { tokens: Array<{ contract_id: string; balance: string; last_update_block_height?: number }> }, bearer, mainnet)

--- a/packages/api/src/near.ts
+++ b/packages/api/src/near.ts
@@ -562,11 +562,17 @@ export const requestSignIn = async ({
   excludedWallets,
   features,
   network,
+  signMessageParams,
 }: {
   contractId?: string;
   excludedWallets?: string[];
   features?: Record<string, boolean>;
   network?: FastNearNetworkId;
+  signMessageParams?: {
+    message: string;
+    recipient: string;
+    nonce: Uint8Array;
+  };
 } = {}) => {
   const provider = getWalletProvider();
   if (!provider) {
@@ -589,6 +595,7 @@ export const requestSignIn = async ({
     network: targetNetwork,
     excludedWallets,
     features,
+    signMessageParams,
   });
 
   if (!result) {
@@ -1589,6 +1596,11 @@ const recipeDiscoveryEntries: FastNearRecipeDiscoveryEntry[] = [
     id: "sign-delegate-actions",
     api: "nearWallet.signDelegateActions",
     title: "How do I sign delegate actions for gasless transactions?",
+  },
+  {
+    id: "connect-and-sign-message",
+    api: "near.recipes.connect",
+    title: "How do I connect a wallet and sign a message in one step?",
   },
   {
     id: "ft-balance",

--- a/packages/api/src/state.ts
+++ b/packages/api/src/state.ts
@@ -242,7 +242,26 @@ let _activeNetwork: FastNearNetworkId = normalizeNetworkId(_config.networkId);
 export let _state: AccountSlot = _networkStates[_activeNetwork];
 
 export interface WalletProvider {
-  connect(options?: { contractId?: string; network?: string; excludedWallets?: string[]; features?: Record<string, boolean> }): Promise<{ accountId: string; network?: string } | null>;
+  connect(options?: {
+    contractId?: string;
+    network?: string;
+    excludedWallets?: string[];
+    features?: Record<string, boolean>;
+    signMessageParams?: {
+      message: string;
+      recipient: string;
+      nonce: Uint8Array;
+    };
+  }): Promise<{
+    accountId: string;
+    network?: string;
+    publicKey?: string;
+    signedMessage?: {
+      accountId: string;
+      publicKey: string;
+      signature: string;
+    };
+  } | null>;
   restore?(options?: { contractId?: string; network?: string }): Promise<{ accountId: string; network?: string } | null>;
   disconnect(options?: { network?: string }): Promise<void>;
   sendTransaction(params: { receiverId: string; actions: any[]; signerId?: string; network?: string }): Promise<any>;

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -94,10 +94,12 @@ export interface RecipeConnectParams {
   contractId?: string;
   excludedWallets?: string[];
   features?: Record<string, boolean>;
-  // When set, opens the wallet picker scoped to this network — otherwise
-  // falls back to `near.config().networkId`. With @fastnear/wallet 1.1.0+
-  // the per-network sessions live alongside each other on the same page.
   network?: "mainnet" | "testnet";
+  signMessageParams?: {
+    message: string;
+    recipient: string;
+    nonce: Uint8Array;
+  };
 }
 
 export interface FastNearRecipeDiscoveryEntry {

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -94,6 +94,9 @@ export interface RecipeConnectParams {
   contractId?: string;
   excludedWallets?: string[];
   features?: Record<string, boolean>;
+  // When set, opens the wallet picker scoped to this network — otherwise
+  // falls back to `near.config().networkId`. With @fastnear/wallet 1.1.0+
+  // the per-network sessions live alongside each other on the same page.
   network?: "mainnet" | "testnet";
   signMessageParams?: {
     message: string;

--- a/packages/wallet/src/connector.ts
+++ b/packages/wallet/src/connector.ts
@@ -370,12 +370,15 @@ export async function connect(
       signMessageParams: options?.signMessageParams,
     });
   } catch (_) {
+    // User closed the modal or wallet rejected
     return null;
   }
   state.connectedWallet = wallet;
   activeNetwork = network;
 
   let publicKey: string | undefined;
+  // Account info is set by the wallet:signIn event handler,
+  // but if it hasn't fired yet, try to get it from the connector.
   if (!state.currentAccountId) {
     try {
       const info = await c.getConnectedWallet();
@@ -383,7 +386,9 @@ export async function connect(
         state.currentAccountId = info.accounts[0].accountId;
         publicKey = info.accounts[0].publicKey;
       }
-    } catch (_) {}
+    } catch (_) {
+      // ignore
+    }
   }
 
   return {

--- a/packages/wallet/src/connector.ts
+++ b/packages/wallet/src/connector.ts
@@ -4,6 +4,7 @@ import {
   type SignAndSendTransactionParams,
   type SignAndSendTransactionsParams,
   type SignMessageParams,
+  type SignedMessage,
   type SignDelegateActionsParams,
   type ConnectorAction,
   type WalletManifest,
@@ -14,7 +15,7 @@ import type {
 } from "@fastnear/near-connect/build/types";
 export type { WalletManifest };
 
-export type { SignDelegateActionsParams } from "@fastnear/near-connect";
+export type { SignDelegateActionsParams, SignedMessage } from "@fastnear/near-connect";
 export type { SignDelegateActionResult, SignDelegateActionsResponse };
 
 type Network = "mainnet" | "testnet";
@@ -41,6 +42,7 @@ export interface ConnectOptions {
     linkText?: string;
     icon?: string;
   } | null;
+  signMessageParams?: Omit<SignMessageParams, "signerId" | "network">;
 }
 
 /**
@@ -88,6 +90,7 @@ export interface ConnectResult {
   accountId: string;
   publicKey?: string;
   network?: Network;
+  signedMessage?: SignedMessage;
 }
 
 type ConnectCallback = (result: ConnectResult) => void;
@@ -342,33 +345,52 @@ export async function connect(
   const network = resolveNetwork(options);
   const state = networkStates[network];
   const c = getOrCreateConnector(options);
+
+  let signedMessageResult: ConnectResult["signedMessage"] | null = null;
+
+  if (options?.signMessageParams) {
+    const handler = (event: any) => {
+      const acct = event?.accounts?.[0];
+      if (acct?.signedMessage) {
+        signedMessageResult = {
+          accountId: acct.signedMessage.accountId,
+          publicKey: acct.signedMessage.publicKey,
+          signature: acct.signedMessage.signature,
+        };
+      }
+      c.off("wallet:signInAndSignMessage", handler);
+    };
+    c.on("wallet:signInAndSignMessage", handler);
+  }
+
   let wallet;
   try {
-    wallet = await c.connect({ walletId: options?.walletId });
+    wallet = await c.connect({
+      walletId: options?.walletId,
+      signMessageParams: options?.signMessageParams,
+    });
   } catch (_) {
-    // User closed the modal or wallet rejected
     return null;
   }
   state.connectedWallet = wallet;
   activeNetwork = network;
 
-  // Account info is set by the wallet:signIn event handler,
-  // but if it hasn't fired yet, try to get it from the connector.
+  let publicKey: string | undefined;
   if (!state.currentAccountId) {
     try {
       const info = await c.getConnectedWallet();
       if (info?.accounts?.length) {
         state.currentAccountId = info.accounts[0].accountId;
+        publicKey = info.accounts[0].publicKey;
       }
-    } catch (_) {
-      // ignore
-    }
+    } catch (_) {}
   }
 
   return {
     accountId: state.currentAccountId ?? "",
-    publicKey: undefined,
+    publicKey,
     network,
+    signedMessage: signedMessageResult ?? undefined,
   };
 }
 

--- a/packages/wallet/src/index.ts
+++ b/packages/wallet/src/index.ts
@@ -20,4 +20,4 @@ export {
   signDelegateActions
 } from "./connector";
 
-export type { ConnectOptions, ConnectResult, WalletManifest, SignDelegateActionsParams, SignDelegateActionResult, SignDelegateActionsResponse } from "./connector";
+export type { ConnectOptions, ConnectResult, WalletManifest, SignedMessage, SignDelegateActionsParams, SignDelegateActionResult, SignDelegateActionsResponse } from "./connector";

--- a/recipes/index.json
+++ b/recipes/index.json
@@ -296,6 +296,7 @@
         "near.recipes.transfer",
         "near.recipes.signMessage",
         "near.recipes.connect",
+        "near.recipes.connect",
         "near.recipes.functionCall"
       ],
       "explain": [
@@ -1257,6 +1258,79 @@
       "followUps": [
         "Submit the signed delegate actions through a relayer service to execute on-chain without the signer paying gas.",
         "If the flow does not need a relayer, use near.recipes.functionCall for a standard wallet-signed transaction instead."
+      ],
+      "pagination": {
+        "kind": "none",
+        "requestFields": [],
+        "responseFields": [],
+        "filtersMustStayStable": false
+      },
+      "relatedRecipes": [
+        "connect-wallet",
+        "sign-message",
+        "function-call"
+      ]
+    },
+    {
+      "id": "connect-and-sign-message",
+      "title": "How do I connect a wallet and sign a message in one step?",
+      "summary": "Combine sign-in and NEP-413 message signing into a single wallet popup instead of two.",
+      "network": "mainnet",
+      "auth": "wallet",
+      "api": "near.recipes.connect",
+      "example": {
+        "contractId": "berryclub.ek.near",
+        "signMessageParams": {
+          "message": "Sign in to myapp.near",
+          "recipient": "myapp.near",
+          "nonce": "(32-byte Uint8Array)"
+        }
+      },
+      "snippets": [
+        {
+          "id": "terminal",
+          "label": "Terminal",
+          "environment": "terminal",
+          "language": "bash",
+          "runnable": false,
+          "reason": "browser_required",
+          "code": "# Browser wallet required.\n# Connecting and signing a message needs a browser environment with a wallet.\n# Use the browser-global or ESM snippet for this task."
+        },
+        {
+          "id": "browser-global",
+          "label": "Browser Global",
+          "environment": "browserGlobal",
+          "language": "js",
+          "runnable": true,
+          "code": "const result = await near.recipes.connect({\n  contractId: \"berryclub.ek.near\",\n  signMessageParams: {\n    message: \"Sign in to FastNear Berry Club\",\n    recipient: window.location.host,\n    nonce: crypto.getRandomValues(new Uint8Array(32)),\n  },\n});\n\nnear.print(result);"
+        },
+        {
+          "id": "esm",
+          "label": "ESM",
+          "environment": "esm",
+          "language": "js",
+          "runnable": true,
+          "code": "import * as near from \"@fastnear/api\";\nimport * as nearWallet from \"@fastnear/wallet\";\n\nnear.config({ apiKey: process.env.FASTNEAR_API_KEY || undefined });\nnear.useWallet(nearWallet);\nawait nearWallet.restore({\n  network: \"mainnet\",\n  contractId: \"berryclub.ek.near\",\n  manifest: \"./manifest.json\",\n});\n\nconst result = await near.recipes.connect({\n  contractId: \"berryclub.ek.near\",\n  signMessageParams: {\n    message: \"Sign in to FastNear Berry Club\",\n    recipient: window.location.host,\n    nonce: crypto.getRandomValues(new Uint8Array(32)),\n  },\n});\n\nnear.print(result);"
+        }
+      ],
+      "service": "wallet",
+      "returns": "{ accountId: string; publicKey?: string; signedMessage?: SignedMessage }",
+      "outputKeys": [
+        "accountId",
+        "publicKey",
+        "signedMessage"
+      ],
+      "responseNotes": [
+        "When signMessageParams is provided, the connector filters the wallet picker to only show wallets with the signInAndSignMessage feature flag.",
+        "The signedMessage field contains the NEP-413 signature result, avoiding a second popup."
+      ],
+      "chooseWhen": [
+        "Choose this when you want sign-in and message signing in a single user interaction.",
+        "Prefer this over separate connect + signMessage calls when the wallet supports signInAndSignMessage."
+      ],
+      "followUps": [
+        "If the wallet doesn't support signInAndSignMessage, fall back to separate near.recipes.connect and near.recipes.signMessage calls.",
+        "After connecting and signing, send one contract action with near.recipes.functionCall."
       ],
       "pagination": {
         "kind": "none",

--- a/recipes/source.mjs
+++ b/recipes/source.mjs
@@ -377,6 +377,17 @@ near.print(result);`,
 
 near.print(result);`,
 
+  connectAndSignMessage: `const result = await near.recipes.connect({
+  contractId: "berryclub.ek.near",
+  signMessageParams: {
+    message: "Sign in to FastNear Berry Club",
+    recipient: window.location.host,
+    nonce: crypto.getRandomValues(new Uint8Array(32)),
+  },
+});
+
+near.print(result);`,
+
   signDelegateActions: `const cu = near.utils.convertUnit;
 
 const result = await nearWallet.signDelegateActions({
@@ -998,6 +1009,33 @@ const walletSnippets = {
       code: withEsmApiKeyConfig(code.functionCallTestnet, { includeWallet: true }),
     },
   ],
+  connectAndSignMessage: [
+    {
+      id: "terminal",
+      label: "Terminal",
+      environment: "terminal",
+      language: "bash",
+      runnable: false,
+      reason: "browser_required",
+      code: browserOnlyTerminalSnippet("Connecting and signing a message needs a browser environment with a wallet."),
+    },
+    {
+      id: "browser-global",
+      label: "Browser Global",
+      environment: "browserGlobal",
+      language: "js",
+      runnable: true,
+      code: code.connectAndSignMessage,
+    },
+    {
+      id: "esm",
+      label: "ESM",
+      environment: "esm",
+      language: "js",
+      runnable: true,
+      code: withEsmApiKeyConfig(code.connectAndSignMessage, { includeWallet: true }),
+    },
+  ],
 };
 
 export const recipeCatalog = [
@@ -1403,6 +1441,41 @@ export const recipeCatalog = [
     followUps: [
       "Submit the signed delegate actions through a relayer service to execute on-chain without the signer paying gas.",
       "If the flow does not need a relayer, use near.recipes.functionCall for a standard wallet-signed transaction instead.",
+    ],
+    pagination: paginationNone,
+    relatedRecipes: ["connect-wallet", "sign-message", "function-call"],
+  }),
+  enrichRecipe({
+    id: "connect-and-sign-message",
+    title: "How do I connect a wallet and sign a message in one step?",
+    summary: "Combine sign-in and NEP-413 message signing into a single wallet popup instead of two.",
+    network: "mainnet",
+    auth: "wallet",
+    api: "near.recipes.connect",
+    example: {
+      contractId: "berryclub.ek.near",
+      signMessageParams: {
+        message: "Sign in to myapp.near",
+        recipient: "myapp.near",
+        nonce: "(32-byte Uint8Array)",
+      },
+    },
+    snippets: walletSnippets.connectAndSignMessage,
+  }, {
+    service: "wallet",
+    returns: "{ accountId: string; publicKey?: string; signedMessage?: SignedMessage }",
+    outputKeys: ["accountId", "publicKey", "signedMessage"],
+    responseNotes: [
+      "When signMessageParams is provided, the connector filters the wallet picker to only show wallets with the signInAndSignMessage feature flag.",
+      "The signedMessage field contains the NEP-413 signature result, avoiding a second popup.",
+    ],
+    chooseWhen: [
+      "Choose this when you want sign-in and message signing in a single user interaction.",
+      "Prefer this over separate connect + signMessage calls when the wallet supports signInAndSignMessage.",
+    ],
+    followUps: [
+      "If the wallet doesn't support signInAndSignMessage, fall back to separate near.recipes.connect and near.recipes.signMessage calls.",
+      "After connecting and signing, send one contract action with near.recipes.functionCall.",
     ],
     pagination: paginationNone,
     relatedRecipes: ["connect-wallet", "sign-message", "function-call"],


### PR DESCRIPTION
`NearConnector.connect()` already accepts `signMessageParams` and routes to `wallet.signInAndSignMessage()` when provided, combining access key creation and NEP-413 message signing into a single wallet popup. But the `@fastnear/wallet` and `@fastnear/api` surfaces only passed `{ walletId }` to the connector, ignoring `signMessageParams` entirely.

## Changes

**`@fastnear/wallet`**
- Add `signMessageParams` to `ConnectOptions` (typed as `Omit<SignMessageParams, "signerId" | "network">` via barrel import)
- Add `signedMessage?: SignedMessage` to `ConnectResult` (using `SignedMessage` re-exported from `@fastnear/near-connect`)
- Rewrite `connect()` to register a `wallet:signInAndSignMessage` event listener before calling `c.connect()`, pass `signMessageParams` through, and include `signedMessage` in the return
- Fix existing bug: `publicKey` now populated from `getConnectedWallet()` instead of always returning `undefined`
- Re-export `SignedMessage` from `index.ts`

**`@fastnear/api`**
- Add `signMessageParams` to `RecipeConnectParams` and `WalletProvider.connect()` options
- Widen `WalletProvider.connect()` return type to include `publicKey?` and `signedMessage?`
- Add `signMessageParams` to `requestSignIn()` and forward to `provider.connect()`
- Add `connect-and-sign-message` discovery entry to `recipeDiscoveryEntries`

**Recipes / docs**
- Add `connect-and-sign-message` recipe to `recipes/source.mjs` (code body, wallet snippets, full recipe entry following the `function-call-testnet` combined-operation pattern)
- Regenerate `recipes/index.json`, `llms.txt`, `llms-full.txt`, and `packages/wallet/README.md`

## What this enables

```js
const result = await nearWallet.connect({
  network: "mainnet",
  contractId: "myapp.near",
  signMessageParams: {
    message: "Sign in to myapp.near",
    recipient: "myapp.near",
    nonce: crypto.getRandomValues(new Uint8Array(32)),
  },
});
// result.signedMessage = { accountId, publicKey, signature }
// One popup instead of two
```

When `signMessageParams` is not provided, behavior is identical to before. When provided, `NearConnector` automatically filters the wallet picker to only show wallets with the `signInAndSignMessage` feature flag.