### PR TITLE
chore: bump Yarn to 4.17.1 to fix Cloudflare Pages build

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,5 +77,5 @@
     "vite": "^7.3.5",
     "@walletconnect/jsonrpc-ws-connection/ws": "^7.5.11"
   },
-  "packageManager": "yarn@4.14.1"
+  "packageManager": "yarn@4.17.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 9
+  version: 10
   cacheKey: 10c0
 
 "@adraffy/ens-normalize@npm:^1.11.0":


### PR DESCRIPTION
## Why

The **Cloudflare Pages** build (`js-monorepo` and `js-wallet-adapter-widget`) has been failing on `main` — independent of the dependency security bumps in #18. Its build command starts with `yarn set version berry`, which upgrades Yarn to the latest release (**4.17.1**). That newer Yarn rewrites the lockfile header `version: 9 → 10`, but Pages installs are immutable, so it dies with:

```
YN0028: The lockfile would have been modified by this install, which is explicitly forbidden.
```

## Fix

Align the repo's pinned Yarn with what the Pages build actually resolves:

- `packageManager`: `yarn@4.14.1` → **`yarn@4.17.1`**
- regenerate `yarn.lock` at metadata **version 10** (the only line that changes — **zero dependency churn**)

`.yarnrc.yml` is intentionally left untouched: Yarn 4.17.1 writes `npmMinimalAgeGate: 0` on a *mutable* install, but it isn't needed for the immutable install CI/Pages run, so this PR doesn't change that supply-chain setting.

> A more durable alternative is to drop `yarn set version berry` from the Pages **Build command** (the repo already pins Yarn via `packageManager`, and Cloudflare auto-activates it). This PR fixes it repo-side so no dashboard change is required.

## Verified (under Yarn 4.17.1)

`yarn install --immutable`, `yarn type-check`, `yarn build` (incl. IIFE), **292 tests**, and `yarn test:agent` all pass.