### PR TITLE
fix(wallet-adapter): normalize malformed Meteor delegate items

### DIFF
--- a/packages/wallet-adapter/src/meteor-delegate.test.ts
+++ b/packages/wallet-adapter/src/meteor-delegate.test.ts
@@ -262,6 +262,40 @@ describe("Meteor delegate signing", () => {
     expect(sendMessageData).not.toHaveBeenCalled();
   });
 
+  it("normalizes a null signed-delegate item into a transport error", async () => {
+    mockFinalBlock(1_000);
+    let listener: ((data: any) => void) | undefined;
+    const bridge: MeteorExtensionBridge = {
+      addMessageDataListener: (next) => {
+        listener = next;
+      },
+      sendMessageData: (message) => {
+        if (message.inputs == null) return;
+        queueMicrotask(() =>
+          listener?.({
+            uid: message.uid,
+            status: "closed_success",
+            payload: { signedDelegatesWithHashes: [null] },
+          }),
+        );
+      },
+    };
+    const meteor = createMeteorAdapter({
+      storage: createStorage(),
+      getExtensionBridge: () => bridge,
+      getNetworkProviders: () => ["https://rpc.testnet.example"],
+    });
+
+    await expect(meteor.signDelegateActions({
+      network: "testnet",
+      delegateActions: [{
+        receiverId: "usdc.fakes.testnet",
+        blockHeightTtl: 300,
+        actions: [],
+      }],
+    })).rejects.toMatchObject({ code: "INVALID_DELEGATE_RESPONSE" });
+  });
+
   it("rejects a non-Borsh response from the wallet transport", async () => {
     mockFinalBlock(1_000);
     let listener: ((data: any) => void) | undefined;

--- a/packages/wallet-adapter/src/meteor.ts
+++ b/packages/wallet-adapter/src/meteor.ts
@@ -683,6 +683,8 @@ export const createMeteorAdapter = (options: MeteorAdapterOptions = {}) => {
     return {
       signedDelegateActions: signedDelegates.map((result, index) => {
         if (
+          result == null ||
+          typeof result !== "object" ||
           typeof result.signedDelegateAction !== "string" ||
           result.signedDelegateAction.length === 0
         ) {


### PR DESCRIPTION
## Summary\n\nReject a null/non-object entry in Meteor's signedDelegatesWithHashes response as TransportError(INVALID_DELEGATE_RESPONSE) instead of leaking a raw TypeError.\n\nThis is a small pre-publication hardening follow-up for 1.4.0.\n\n## Verification\n\n- Meteor delegate suite: 6/6\n- wallet-adapter type-check\n- git diff --check