### PR TITLE
Add @fastnear/x402

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The monorepo now ships a low-level-first runtime plus a compact task catalog for
 - `near.explain.*` turns actions, transactions, and thrown errors into stable JSON summaries.
 - The original low-level entrypoints stay intact: `near.view`, `near.queryAccount`, `near.queryTx`, `near.sendTx`, `near.requestSignIn`, and `near.signMessage`.
 - `near.batch(...)` and `near.view.many(...)` fan out many reads with settled, concurrency-capped results, and `near.config({ retry, batch })` tunes automatic 429/transient retry — both on by default. See the API package README for details.
-- `@fastnear/x402` provides opt-in x402 v2 NEAR payment clients plus focused `/node`, `/server`, and `/facilitator` entrypoints; its browser-wallet path is beta while wallet production manifests remain QA-gated.
+- `@fastnear/x402` provides opt-in x402 v2 NEAR payment clients plus focused `/node`, `/server`, and `/facilitator` entrypoints; browser-wallet payments require a timeout-aware wallet, with Meteor Wallet tested for this release.
 
 ### Hosted agent entrypoint
 
@@ -529,14 +529,14 @@ export async function findMlDsa65AccessKey({ accountId, publicKey }) {
 - Authorization: NEP-366 SignedDelegate; asset: NEP-141 fungible tokens.
 - Browser global: `nearX402`.
 - Runtime: Package-only; not included in agents.js or near.js.
-- Browser status: Beta: requires @fastnear/near-connect 0.13+ and a wallet that advertises both timeout-aware delegate-signing capabilities; production wallet manifest activation remains QA-gated.
+- Browser status: Stable with tested Meteor Wallet support; other wallets must advertise both timeout-aware delegate-signing capabilities and pass the x402 testnet harness before being documented as compatible.
 - Required wallet features: `signDelegateActions` and `signDelegateActionsWithTtl`.
 - Package guide: [https://github.com/fastnear/js-monorepo/blob/main/packages/x402/README.md](https://github.com/fastnear/js-monorepo/blob/main/packages/x402/README.md).
 
 #### Choose by task
 
-- Pay an x402 URL from Node.js: `createLocalNearSigner` + `createNearPaymentFetch` from `@fastnear/x402/node` and `@fastnear/x402` — stable core path.
-- Pay an x402 URL from a browser wallet: `createFastNearWalletSigner` + `createNearPaymentFetch` from `@fastnear/wallet` and `@fastnear/x402` — beta until Intear and Meteor production wallet QA pass.
+- Pay an x402 URL from Node.js: `createLocalNearSigner` + `createNearPaymentFetch` from `@fastnear/x402/node` and `@fastnear/x402` — stable.
+- Pay an x402 URL from a browser wallet: `createFastNearWalletSigner` + `createNearPaymentFetch` from `@fastnear/wallet` and `@fastnear/x402` — stable with a compatible timeout-aware wallet; Meteor Wallet is the tested production path.
 - Protect a seller resource: `createNearResourceServer` from `@fastnear/x402/server` — requires an explicit facilitator.
 - Operate a NEAR facilitator: `createNearFacilitator` from `@fastnear/x402/facilitator` — HTTP framework and secret storage are operator choices.
 - Integrate below the paid-fetch helper: `createNearX402Client` from `@fastnear/x402` — lower-level client path.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The monorepo now ships a low-level-first runtime plus a compact task catalog for
 - `near.explain.*` turns actions, transactions, and thrown errors into stable JSON summaries.
 - The original low-level entrypoints stay intact: `near.view`, `near.queryAccount`, `near.queryTx`, `near.sendTx`, `near.requestSignIn`, and `near.signMessage`.
 - `near.batch(...)` and `near.view.many(...)` fan out many reads with settled, concurrency-capped results, and `near.config({ retry, batch })` tunes automatic 429/transient retry — both on by default. See the API package README for details.
-- `@fastnear/x402` provides opt-in x402 v2 NEAR payment clients plus focused `/node`, `/server`, and `/facilitator` entrypoints; its browser-wallet path is a preview pending the timeout-aware wallet bridge.
+- `@fastnear/x402` provides opt-in x402 v2 NEAR payment clients plus focused `/node`, `/server`, and `/facilitator` entrypoints; its browser-wallet path is beta while wallet production manifests remain QA-gated.
 
 ### Hosted agent entrypoint
 
@@ -529,14 +529,14 @@ export async function findMlDsa65AccessKey({ accountId, publicKey }) {
 - Authorization: NEP-366 SignedDelegate; asset: NEP-141 fungible tokens.
 - Browser global: `nearX402`.
 - Runtime: Package-only; not included in agents.js or near.js.
-- Browser status: Preview: requires a compatible upcoming near-connect release and a wallet that advertises timeout-aware delegate signing; the currently published wallet bridge is not production-compatible.
+- Browser status: Beta: requires @fastnear/near-connect 0.13+ and a wallet that advertises both timeout-aware delegate-signing capabilities; production wallet manifest activation remains QA-gated.
 - Required wallet features: `signDelegateActions` and `signDelegateActionsWithTtl`.
 - Package guide: [https://github.com/fastnear/js-monorepo/blob/main/packages/x402/README.md](https://github.com/fastnear/js-monorepo/blob/main/packages/x402/README.md).
 
 #### Choose by task
 
 - Pay an x402 URL from Node.js: `createLocalNearSigner` + `createNearPaymentFetch` from `@fastnear/x402/node` and `@fastnear/x402` — stable core path.
-- Pay an x402 URL from a browser wallet: `createFastNearWalletSigner` + `createNearPaymentFetch` from `@fastnear/wallet` and `@fastnear/x402` — preview until the timeout-aware wallet bridge ships.
+- Pay an x402 URL from a browser wallet: `createFastNearWalletSigner` + `createNearPaymentFetch` from `@fastnear/wallet` and `@fastnear/x402` — beta until Intear and Meteor production wallet QA pass.
 - Protect a seller resource: `createNearResourceServer` from `@fastnear/x402/server` — requires an explicit facilitator.
 - Operate a NEAR facilitator: `createNearFacilitator` from `@fastnear/x402/facilitator` — HTTP framework and secret storage are operator choices.
 - Integrate below the paid-fetch helper: `createNearX402Client` from `@fastnear/x402` — lower-level client path.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The monorepo now ships a low-level-first runtime plus a compact task catalog for
 - `near.explain.*` turns actions, transactions, and thrown errors into stable JSON summaries.
 - The original low-level entrypoints stay intact: `near.view`, `near.queryAccount`, `near.queryTx`, `near.sendTx`, `near.requestSignIn`, and `near.signMessage`.
 - `near.batch(...)` and `near.view.many(...)` fan out many reads with settled, concurrency-capped results, and `near.config({ retry, batch })` tunes automatic 429/transient retry — both on by default. See the API package README for details.
+- `@fastnear/x402` provides opt-in x402 v2 NEAR payment clients plus focused `/node`, `/server`, and `/facilitator` entrypoints; its browser-wallet path is a preview pending the timeout-aware wallet bridge.
 
 ### Hosted agent entrypoint
 
@@ -520,6 +521,92 @@ export async function findMlDsa65AccessKey({ accountId, publicKey }) {
 }
 ```
 
+### x402 payments on NEAR
+
+`@fastnear/x402` adapts the official x402 Foundation NEAR mechanism without introducing another wire format.
+
+- Protocol: x402 v2 `exact` on `near:mainnet` and `near:testnet`.
+- Authorization: NEP-366 SignedDelegate; asset: NEP-141 fungible tokens.
+- Browser global: `nearX402`.
+- Runtime: Package-only; not included in agents.js or near.js.
+- Browser status: Preview: requires a compatible upcoming near-connect release and a wallet that advertises timeout-aware delegate signing; the currently published wallet bridge is not production-compatible.
+- Required wallet features: `signDelegateActions` and `signDelegateActionsWithTtl`.
+- Package guide: [https://github.com/fastnear/js-monorepo/blob/main/packages/x402/README.md](https://github.com/fastnear/js-monorepo/blob/main/packages/x402/README.md).
+
+#### Choose by task
+
+- Pay an x402 URL from Node.js: `createLocalNearSigner` + `createNearPaymentFetch` from `@fastnear/x402/node` and `@fastnear/x402` — stable core path.
+- Pay an x402 URL from a browser wallet: `createFastNearWalletSigner` + `createNearPaymentFetch` from `@fastnear/wallet` and `@fastnear/x402` — preview until the timeout-aware wallet bridge ships.
+- Protect a seller resource: `createNearResourceServer` from `@fastnear/x402/server` — requires an explicit facilitator.
+- Operate a NEAR facilitator: `createNearFacilitator` from `@fastnear/x402/facilitator` — HTTP framework and secret storage are operator choices.
+- Integrate below the paid-fetch helper: `createNearX402Client` from `@fastnear/x402` — lower-level client path.
+
+#### Entrypoints
+
+- `@fastnear/x402`: `createFastNearWalletSigner`, `createNearX402Client`, `createNearPaymentFetch` — injected FastNEAR wallet signer, NEAR-only x402 client, and paid fetch.
+- `@fastnear/x402/node`: `createLocalNearSigner` — official RPC-backed local full-access-key signer.
+- `@fastnear/x402/server`: `createNearResourceServer` — resource server with one or more explicitly configured facilitators.
+- `@fastnear/x402/facilitator`: `createNearFacilitator` — self-hosted facilitator registration for concrete NEAR networks.
+
+#### Constraints
+
+- Only x402 v2 exact payments on near:mainnet and near:testnet are supported.
+- Payments use NEP-141 tokens; native NEAR is not a direct payment asset.
+- Wallet and local-key payers require full-access keys, and recipients need token storage registration.
+- Resource servers require an explicit facilitator; no x402.org or other default is selected.
+- Browser wallet access is injected explicitly and payment occurs only when the application calls the paid fetch function.
+
+#### Safe defaults
+
+- Pin near:testnet during development and a concrete NEAR network in production; use near:* only for an intentionally cross-network client.
+- Keep payer and relayer secret keys in server-side secret storage, never browser code.
+- String and number seller prices use the official USDC contract; wNEAR and custom tokens require an explicit { amount, asset } price.
+- Always configure a facilitator explicitly.
+
+#### Pay an x402 URL from Node.js
+
+Quickstart ID: `x402-node-paid-fetch`
+
+Use the upstream local full-access-key signer with the high-level paid-fetch helper.
+
+```js
+import { createNearPaymentFetch } from "@fastnear/x402";
+import { createLocalNearSigner } from "@fastnear/x402/node";
+
+const { NEAR_PAYER_ACCOUNT_ID, NEAR_PAYER_SECRET_KEY, X402_RESOURCE_URL } = process.env;
+if (!NEAR_PAYER_ACCOUNT_ID || !NEAR_PAYER_SECRET_KEY || !X402_RESOURCE_URL) {
+  throw new Error("NEAR_PAYER_ACCOUNT_ID, NEAR_PAYER_SECRET_KEY, and X402_RESOURCE_URL are required");
+}
+
+const signer = createLocalNearSigner({
+  accountId: NEAR_PAYER_ACCOUNT_ID,
+  secretKey: NEAR_PAYER_SECRET_KEY,
+  rpcUrls: { "near:testnet": "https://rpc.testnet.fastnear.com" },
+});
+const paidFetch = createNearPaymentFetch({ signer, network: "near:testnet" });
+const response = await paidFetch(X402_RESOURCE_URL);
+if (!response.ok) throw new Error(`Paid request failed: ${response.status}`);
+console.log(await response.json());
+```
+
+#### Configure a seller with an explicit remote facilitator
+
+Quickstart ID: `x402-remote-facilitator-seller`
+
+Create the NEAR resource-server core, then pass it to the x402 HTTP framework adapter you choose.
+
+```js
+import { createNearResourceServer } from "@fastnear/x402/server";
+
+const { X402_FACILITATOR_URL } = process.env;
+if (!X402_FACILITATOR_URL) throw new Error("X402_FACILITATOR_URL is required");
+
+export const resourceServer = createNearResourceServer({
+  facilitators: { url: X402_FACILITATOR_URL },
+});
+await resourceServer.initialize();
+```
+
 ### Structured explain helpers
 
 - `near.explain.action`: Normalize one action into a stable JSON summary.
@@ -533,7 +620,7 @@ The repo keeps the confidence ladder intentionally small:
 
 - `yarn test` is the fast local and PR path. It runs Vitest plus the local generated-snippet smoke.
 - `yarn smoke:services:live` is the live infrastructure check. It does one read-only call per FastNear family, including a pinned archival RPC read.
-- `yarn smoke:agent:published` is the manual published-surface gate. Use it after publish when you want to verify the public `agents.js`, `recipes.json`, and `llms.txt` assets.
+- `yarn smoke:agent:published` is the manual published-surface gate. Use it after publish to verify `agents.js`, `near.js`, `recipes.json`, `llms.txt`, and `llms-full.txt`, including the package-only x402 metadata.
 
 ## Using this repo
 

--- a/examples/static/index.html
+++ b/examples/static/index.html
@@ -46,6 +46,12 @@
     <span class="tag tag-mainnet">mainnet</span> <span class="tag tag-wallet">wallet</span> <span class="tag tag-session-keys">session keys</span>
   </a>
 
+  <a class="card" href="x402.html">
+    <h2>x402 payments (preview)</h2>
+    <p>Explicitly pay and retry an x402-protected request with a timeout-aware NEP-366 wallet bridge.</p>
+    <span class="tag tag-testnet">testnet</span> <span class="tag tag-wallet">wallet</span> <span class="tag">preview</span>
+  </a>
+
 </div>
 <footer class="brand-footer">&copy; 2026 FastNear · <a href="https://github.com/fastnear/js-monorepo" target="_blank" rel="noopener">GitHub</a></footer>
 </body>

--- a/examples/static/index.html
+++ b/examples/static/index.html
@@ -47,9 +47,9 @@
   </a>
 
   <a class="card" href="x402.html">
-    <h2>x402 payments (preview)</h2>
+    <h2>x402 payments</h2>
     <p>Explicitly pay and retry an x402-protected request with a timeout-aware NEP-366 wallet bridge.</p>
-    <span class="tag tag-testnet">testnet</span> <span class="tag tag-wallet">wallet</span> <span class="tag">preview</span>
+    <span class="tag tag-testnet">testnet</span> <span class="tag tag-wallet">wallet</span> <span class="tag">x402</span>
   </a>
 
 </div>

--- a/examples/static/x402.html
+++ b/examples/static/x402.html
@@ -81,6 +81,10 @@
   let connectedNetwork = null;
   let connectedWalletName = null;
   const smokeConfig = globalThis.__FASTNEAR_X402_SMOKE__ || null;
+  const requiredWalletFeatures = {
+    signDelegateActions: true,
+    signDelegateActionsWithTtl: true,
+  };
 
   function selectedNetwork() {
     return document.getElementById('network').value;
@@ -92,6 +96,25 @@
 
   function showResult(message) {
     document.getElementById('result').textContent = message;
+  }
+
+  function connectOptionsFor(network) {
+    return {
+      network,
+      ...(smokeConfig && smokeConfig.manifest ? { manifest: smokeConfig.manifest } : {}),
+      features: requiredWalletFeatures,
+    };
+  }
+
+  function walletSummary(wallets) {
+    return wallets.map((wallet) => `${wallet.name || wallet.id} (${wallet.id})`).join(', ');
+  }
+
+  async function availableCompatibleWallets(network) {
+    const connectOptions = connectOptionsFor(network);
+    return typeof nearWallet.availableWallets === 'function'
+      ? await nearWallet.availableWallets(connectOptions)
+      : [];
   }
 
   function setConnected(network, accountId) {
@@ -112,23 +135,13 @@
     }
 
     const network = selectedNetwork();
-    const walletFeatures = {
-      signDelegateActions: true,
-      signDelegateActionsWithTtl: true,
-    };
-    const connectOptions = {
-      network,
-      ...(smokeConfig && smokeConfig.manifest ? { manifest: smokeConfig.manifest } : {}),
-      features: walletFeatures,
-    };
+    const connectOptions = connectOptionsFor(network);
     try {
       setStatus('Checking compatible wallets...');
-      const wallets = typeof nearWallet.availableWallets === 'function'
-        ? await nearWallet.availableWallets(connectOptions)
-        : [];
-      const walletSummary = wallets.map((wallet) => `${wallet.name || wallet.id} (${wallet.id})`).join(', ');
+      const wallets = await availableCompatibleWallets(network);
+      const summary = walletSummary(wallets);
       if (smokeConfig && wallets.length !== 1) {
-        throw new Error(`Expected exactly one candidate wallet; found ${wallets.length}${walletSummary ? `: ${walletSummary}` : ''}.`);
+        throw new Error(`Expected exactly one candidate wallet; found ${wallets.length}${summary ? `: ${summary}` : ''}.`);
       }
 
       setStatus(smokeConfig
@@ -141,8 +154,8 @@
 
       if (!connection) {
         setConnected(null, null);
-        showResult(walletSummary
-          ? `No compatible wallet was connected. Candidate wallets: ${walletSummary}. Check whether the wallet popup was closed, rejected, or blocked.`
+        showResult(summary
+          ? `No compatible wallet was connected. Candidate wallets: ${summary}. Check whether the wallet popup was closed, rejected, or blocked.`
           : 'No compatible wallet was connected. The manifest did not expose a wallet with both delegate-signing features.');
         return;
       }
@@ -230,7 +243,28 @@
     setStatus('One-shot testnet smoke — connect the exact expected account; no payment occurs until Pay is clicked.');
   }
 
+  async function reportSmokeWalletCandidates() {
+    if (!smokeConfig) return;
+    if (!globalThis.nearWallet) {
+      showResult('Wallet bundle is unavailable. Check the @fastnear/wallet script URL.');
+      return;
+    }
+
+    try {
+      const wallets = await availableCompatibleWallets(selectedNetwork());
+      const summary = walletSummary(wallets);
+      if (wallets.length === 1) {
+        showResult(`Candidate wallet loaded: ${summary}. Click Connect compatible wallet to open it.`);
+      } else {
+        showResult(`Candidate wallet check found ${wallets.length}${summary ? `: ${summary}` : ''}.`);
+      }
+    } catch (error) {
+      showResult(`Candidate wallet check failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
   applySmokeConfiguration();
+  reportSmokeWalletCandidates();
 </script>
 <footer class="brand-footer">&copy; 2026 FastNear · <a href="https://github.com/fastnear/js-monorepo" target="_blank" rel="noopener">GitHub</a></footer>
 </body>

--- a/examples/static/x402.html
+++ b/examples/static/x402.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="theme-color" content="#f0f4f8" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#0d102d" media="(prefers-color-scheme: dark)">
+  <link rel="icon" href="assets/favicon.ico">
+  <link rel="apple-touch-icon" href="assets/fastnear_logo_black.png">
+  <title>x402 payments — @fastnear preview</title>
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="x402 payments — @fastnear preview">
+  <meta property="og:description" content="Preview an x402 NEP-141 payment with a compatible FastNEAR wallet.">
+  <meta property="og:image" content="assets/fastnear_logo_black.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+
+  <!-- Preview channel: pin released versions before production use. -->
+  <script src="https://cdn.jsdelivr.net/npm/@fastnear/wallet@next/dist/umd/browser.global.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@fastnear/x402@next/dist/umd/browser.global.js"></script>
+</head>
+<body>
+<div class="container">
+  <header class="brand-header">
+    <a class="brand-wordmark" href="index.html">FastNear</a>
+    <hr class="brand-divider">
+  </header>
+
+  <h1>x402 NEAR payment preview</h1>
+  <p class="subtitle">
+    Pay an x402-protected endpoint with an NEP-141 token
+    &nbsp;·&nbsp; <a href="index.html">back</a>
+  </p>
+
+  <div class="status-bar" id="status-bar">
+    Preview only — the timeout-aware wallet bridge is not yet available in the published wallet stack.
+  </div>
+
+  <section>
+    <h2>1. Choose the challenge network</h2>
+    <select id="network" style="width: 100%; padding: 8px 12px; margin-bottom: 8px;">
+      <option value="testnet" selected>NEAR testnet</option>
+      <option value="mainnet">NEAR mainnet</option>
+    </select>
+    <button id="btn-connect" class="primary" onclick="handleConnect()">Connect compatible wallet</button>
+    <button id="btn-disconnect" class="danger" onclick="handleDisconnect()" disabled>Disconnect</button>
+    <p class="note">
+      The wallet picker requests both <code>signDelegateActions</code> and
+      <code>signDelegateActionsWithTtl</code>. Intear and Meteor support are release gates for this preview.
+    </p>
+  </section>
+
+  <section>
+    <h2>2. Enter an x402-protected URL</h2>
+    <input id="target-url" type="text" value="http://localhost:4021/weather" aria-label="Protected URL">
+    <button id="btn-pay" class="accent" onclick="handlePaidFetch()" disabled>Pay and fetch</button>
+    <p class="note">
+      No request or payment happens until you click this button. The endpoint must allow this page's origin through CORS.
+    </p>
+  </section>
+
+  <section id="smoke-fixture" hidden>
+    <h2>Locked testnet fixture</h2>
+    <div id="smoke-fixture-details" class="log"></div>
+    <p class="note">
+      The local smoke server fixes the payer, token, amount, recipient, and endpoint.
+      It accepts one settlement and then shuts down.
+    </p>
+  </section>
+
+  <section>
+    <h2>Result</h2>
+    <div id="result" class="log">(connect a compatible wallet, then click Pay and fetch)</div>
+  </section>
+</div>
+
+<script>
+  let connectedNetwork = null;
+  let connectedWalletName = null;
+  const smokeConfig = globalThis.__FASTNEAR_X402_SMOKE__ || null;
+
+  function selectedNetwork() {
+    return document.getElementById('network').value;
+  }
+
+  function setStatus(message) {
+    document.getElementById('status-bar').textContent = message;
+  }
+
+  function showResult(message) {
+    document.getElementById('result').textContent = message;
+  }
+
+  function setConnected(network, accountId) {
+    connectedNetwork = network;
+    document.getElementById('network').disabled = Boolean(accountId);
+    document.getElementById('btn-connect').disabled = Boolean(accountId);
+    document.getElementById('btn-disconnect').disabled = !accountId;
+    document.getElementById('btn-pay').disabled = !accountId;
+    setStatus(accountId
+      ? `Connected to ${connectedWalletName || 'wallet'} as ${accountId} on ${network}`
+      : 'Not connected');
+  }
+
+  async function handleConnect() {
+    if (!globalThis.nearWallet || !globalThis.nearX402) {
+      showResult('Preview bundles are unavailable. Publish/install the compatible @next releases first.');
+      return;
+    }
+
+    const network = selectedNetwork();
+    try {
+      setStatus('Opening the compatible-wallet picker...');
+      const connection = await nearWallet.connect({
+        network,
+        ...(smokeConfig && smokeConfig.manifest ? { manifest: smokeConfig.manifest } : {}),
+        features: {
+          signDelegateActions: true,
+          signDelegateActionsWithTtl: true,
+        },
+      });
+
+      if (!connection) {
+        setConnected(null, null);
+        showResult('No compatible wallet was connected.');
+        return;
+      }
+
+      const accountId = nearWallet.accountId({ network }) || connection.accountId;
+      const walletName = nearWallet.walletName({ network });
+      if (smokeConfig && accountId !== smokeConfig.payer) {
+        await nearWallet.disconnect({ network });
+        throw new Error(`This smoke session requires ${smokeConfig.payer}; the wallet connected ${accountId}.`);
+      }
+      if (smokeConfig && walletName !== smokeConfig.expectedWallet) {
+        await nearWallet.disconnect({ network });
+        throw new Error(`This smoke session requires ${smokeConfig.expectedWallet}; the selected wallet reports ${walletName || 'no name'}.`);
+      }
+      connectedWalletName = walletName;
+      setConnected(network, accountId);
+      showResult('Ready. The payment request still has not been sent.');
+    } catch (error) {
+      setConnected(null, null);
+      showResult(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  async function handleDisconnect() {
+    if (!connectedNetwork) return;
+    try {
+      await nearWallet.disconnect({ network: connectedNetwork });
+    } finally {
+      connectedWalletName = null;
+      setConnected(null, null);
+      showResult('(disconnected)');
+    }
+  }
+
+  async function handlePaidFetch() {
+    const url = document.getElementById('target-url').value.trim();
+    if (!url || !connectedNetwork) {
+      showResult('Connect a compatible wallet and enter a URL first.');
+      return;
+    }
+
+    const button = document.getElementById('btn-pay');
+    button.disabled = true;
+    let paymentCompleted = false;
+    showResult('Requesting the resource. Approve the exact token transfer if the server returns 402...');
+
+    try {
+      const signer = nearX402.createFastNearWalletSigner({ wallet: nearWallet });
+      const paidFetch = nearX402.createNearPaymentFetch({
+        signer,
+        network: `near:${connectedNetwork}`,
+      });
+      const response = await paidFetch(url, smokeConfig ? {
+        headers: { 'X-FastNear-Smoke-Wallet': connectedWalletName },
+      } : undefined);
+      const body = await response.text();
+      showResult(`HTTP ${response.status} ${response.statusText}\n\n${body}`);
+      paymentCompleted = Boolean(smokeConfig && response.ok);
+    } catch (error) {
+      showResult(error instanceof Error ? error.stack || error.message : String(error));
+    } finally {
+      button.disabled = paymentCompleted;
+    }
+  }
+
+  function applySmokeConfiguration() {
+    if (!smokeConfig) return;
+    const network = document.getElementById('network');
+    network.innerHTML = '<option value="testnet" selected>NEAR testnet</option>';
+    network.disabled = true;
+
+    const target = document.getElementById('target-url');
+    target.value = smokeConfig.endpoint;
+    target.readOnly = true;
+
+    document.getElementById('smoke-fixture').hidden = false;
+    document.getElementById('smoke-fixture-details').textContent = [
+      `Expected payer: ${smokeConfig.payer}`,
+      `Expected wallet: ${smokeConfig.expectedWallet}`,
+      `Token: ${smokeConfig.asset}`,
+      `Amount: ${smokeConfig.amount} atomic units`,
+      `Recipient: ${smokeConfig.payTo}`,
+      `Endpoint: ${smokeConfig.endpoint}`,
+    ].join('\n');
+    setStatus('One-shot testnet smoke — connect the exact expected account; no payment occurs until Pay is clicked.');
+  }
+
+  applySmokeConfiguration();
+</script>
+<footer class="brand-footer">&copy; 2026 FastNear · <a href="https://github.com/fastnear/js-monorepo" target="_blank" rel="noopener">GitHub</a></footer>
+</body>
+</html>

--- a/examples/static/x402.html
+++ b/examples/static/x402.html
@@ -7,10 +7,10 @@
   <meta name="theme-color" content="#0d102d" media="(prefers-color-scheme: dark)">
   <link rel="icon" href="assets/favicon.ico">
   <link rel="apple-touch-icon" href="assets/fastnear_logo_black.png">
-  <title>x402 payments — @fastnear preview</title>
+  <title>x402 payments — @fastnear beta</title>
   <meta property="og:type" content="website">
-  <meta property="og:title" content="x402 payments — @fastnear preview">
-  <meta property="og:description" content="Preview an x402 NEP-141 payment with a compatible FastNEAR wallet.">
+  <meta property="og:title" content="x402 payments — @fastnear beta">
+  <meta property="og:description" content="Try an x402 NEP-141 payment with a compatible FastNEAR wallet.">
   <meta property="og:image" content="assets/fastnear_logo_black.png">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -18,7 +18,7 @@
   <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 
-  <!-- Preview channel: pin released versions before production use. -->
+  <!-- Beta channel: pin exact released versions before production use. -->
   <script src="https://cdn.jsdelivr.net/npm/@fastnear/wallet@next/dist/umd/browser.global.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@fastnear/x402@next/dist/umd/browser.global.js"></script>
 </head>
@@ -29,14 +29,14 @@
     <hr class="brand-divider">
   </header>
 
-  <h1>x402 NEAR payment preview</h1>
+  <h1>x402 NEAR payment beta</h1>
   <p class="subtitle">
     Pay an x402-protected endpoint with an NEP-141 token
     &nbsp;·&nbsp; <a href="index.html">back</a>
   </p>
 
   <div class="status-bar" id="status-bar">
-    Preview only — the timeout-aware wallet bridge is not yet available in the published wallet stack.
+    Beta only — requires a wallet that advertises both timeout-aware delegate-signing capabilities.
   </div>
 
   <section>
@@ -49,7 +49,7 @@
     <button id="btn-disconnect" class="danger" onclick="handleDisconnect()" disabled>Disconnect</button>
     <p class="note">
       The wallet picker requests both <code>signDelegateActions</code> and
-      <code>signDelegateActionsWithTtl</code>. Intear and Meteor support are release gates for this preview.
+      <code>signDelegateActionsWithTtl</code>. Intear and Meteor production manifests remain QA-gated.
     </p>
   </section>
 
@@ -107,7 +107,7 @@
 
   async function handleConnect() {
     if (!globalThis.nearWallet || !globalThis.nearX402) {
-      showResult('Preview bundles are unavailable. Publish/install the compatible @next releases first.');
+      showResult('Beta bundles are unavailable. Publish/install the compatible @next releases first.');
       return;
     }
 

--- a/examples/static/x402.html
+++ b/examples/static/x402.html
@@ -154,9 +154,11 @@
 
       if (!connection) {
         setConnected(null, null);
-        showResult(summary
+        const message = summary
           ? `No compatible wallet was connected. Candidate wallets: ${summary}. Check whether the wallet popup was closed, rejected, or blocked.`
-          : 'No compatible wallet was connected. The manifest did not expose a wallet with both delegate-signing features.');
+          : 'No compatible wallet was connected. The manifest did not expose a wallet with both delegate-signing features.';
+        setStatus(`Connect failed: ${message}`);
+        showResult(message);
         return;
       }
 
@@ -174,8 +176,10 @@
       setConnected(network, accountId);
       showResult('Ready. The payment request still has not been sent.');
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
       setConnected(null, null);
-      showResult(error instanceof Error ? error.message : String(error));
+      setStatus(`Connect failed: ${message}`);
+      showResult(message);
     }
   }
 

--- a/examples/static/x402.html
+++ b/examples/static/x402.html
@@ -7,9 +7,9 @@
   <meta name="theme-color" content="#0d102d" media="(prefers-color-scheme: dark)">
   <link rel="icon" href="assets/favicon.ico">
   <link rel="apple-touch-icon" href="assets/fastnear_logo_black.png">
-  <title>x402 payments — @fastnear beta</title>
+  <title>x402 payments — @fastnear</title>
   <meta property="og:type" content="website">
-  <meta property="og:title" content="x402 payments — @fastnear beta">
+  <meta property="og:title" content="x402 payments — @fastnear">
   <meta property="og:description" content="Try an x402 NEP-141 payment with a compatible FastNEAR wallet.">
   <meta property="og:image" content="assets/fastnear_logo_black.png">
   <meta name="twitter:card" content="summary_large_image">
@@ -18,9 +18,9 @@
   <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 
-  <!-- Beta channel: pin exact released versions before production use. -->
-  <script src="https://cdn.jsdelivr.net/npm/@fastnear/wallet@next/dist/umd/browser.global.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@fastnear/x402@next/dist/umd/browser.global.js"></script>
+  <!-- Pin exact released versions for production use. -->
+  <script src="https://cdn.jsdelivr.net/npm/@fastnear/wallet@1.5.0/dist/umd/browser.global.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@fastnear/x402@1.5.0/dist/umd/browser.global.js"></script>
 </head>
 <body>
 <div class="container">
@@ -29,14 +29,14 @@
     <hr class="brand-divider">
   </header>
 
-  <h1>x402 NEAR payment beta</h1>
+  <h1>x402 NEAR payment</h1>
   <p class="subtitle">
     Pay an x402-protected endpoint with an NEP-141 token
     &nbsp;·&nbsp; <a href="index.html">back</a>
   </p>
 
   <div class="status-bar" id="status-bar">
-    Beta only — requires a wallet that advertises both timeout-aware delegate-signing capabilities.
+    Requires a wallet that advertises both timeout-aware delegate-signing capabilities.
   </div>
 
   <section>
@@ -49,7 +49,7 @@
     <button id="btn-disconnect" class="danger" onclick="handleDisconnect()" disabled>Disconnect</button>
     <p class="note">
       The wallet picker requests both <code>signDelegateActions</code> and
-      <code>signDelegateActionsWithTtl</code>. Intear and Meteor production manifests remain QA-gated.
+      <code>signDelegateActionsWithTtl</code>. Meteor Wallet is the tested production path.
     </p>
   </section>
 
@@ -130,7 +130,7 @@
 
   async function handleConnect() {
     if (!globalThis.nearWallet || !globalThis.nearX402) {
-      showResult('Beta bundles are unavailable. Publish/install the compatible @next releases first.');
+      showResult('x402 bundles are unavailable. Publish/install the compatible released packages first.');
       return;
     }
 

--- a/examples/static/x402.html
+++ b/examples/static/x402.html
@@ -112,20 +112,38 @@
     }
 
     const network = selectedNetwork();
+    const walletFeatures = {
+      signDelegateActions: true,
+      signDelegateActionsWithTtl: true,
+    };
+    const connectOptions = {
+      network,
+      ...(smokeConfig && smokeConfig.manifest ? { manifest: smokeConfig.manifest } : {}),
+      features: walletFeatures,
+    };
     try {
-      setStatus('Opening the compatible-wallet picker...');
+      setStatus('Checking compatible wallets...');
+      const wallets = typeof nearWallet.availableWallets === 'function'
+        ? await nearWallet.availableWallets(connectOptions)
+        : [];
+      const walletSummary = wallets.map((wallet) => `${wallet.name || wallet.id} (${wallet.id})`).join(', ');
+      if (smokeConfig && wallets.length !== 1) {
+        throw new Error(`Expected exactly one candidate wallet; found ${wallets.length}${walletSummary ? `: ${walletSummary}` : ''}.`);
+      }
+
+      setStatus(smokeConfig
+        ? `Opening ${wallets[0].name || wallets[0].id}...`
+        : 'Opening the compatible-wallet picker...');
       const connection = await nearWallet.connect({
-        network,
-        ...(smokeConfig && smokeConfig.manifest ? { manifest: smokeConfig.manifest } : {}),
-        features: {
-          signDelegateActions: true,
-          signDelegateActionsWithTtl: true,
-        },
+        ...connectOptions,
+        ...(smokeConfig && wallets[0]?.id ? { walletId: wallets[0].id } : {}),
       });
 
       if (!connection) {
         setConnected(null, null);
-        showResult('No compatible wallet was connected.');
+        showResult(walletSummary
+          ? `No compatible wallet was connected. Candidate wallets: ${walletSummary}. Check whether the wallet popup was closed, rejected, or blocked.`
+          : 'No compatible wallet was connected. The manifest did not expose a wallet with both delegate-signing features.');
         return;
       }
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1813,7 +1813,7 @@ near.print(result);
 - Network: `mainnet`
 - Auth: `wallet`
 - Summary: Sign NEP-366 delegate actions via the connected wallet so a relayer can submit them on-chain without the user paying gas.
-- Output keys: `signedDelegateActions[].delegateHash`, `signedDelegateActions[].signedDelegate`
+- Output keys: `signedDelegateActions[].borshSerializedBase64`
 - Pagination: none; request fields: none; response fields: none; filters must stay stable: no
 
 Choose this when:
@@ -1823,8 +1823,10 @@ Choose this when:
 
 Response notes:
 
+- The canonical result is { borshSerializedBase64: string }; legacy structured delegates and bare base64 strings remain in the public union for compatibility.
 - Returns signed delegate actions that a relayer can submit on-chain, enabling gasless transactions for the user.
 - The wallet must support the signDelegateActions feature (check WalletFeatures.signDelegateActions).
+- Requests that include blockHeightTtl additionally require WalletFeatures.signDelegateActionsWithTtl.
 
 Follow-ups:
 
@@ -1898,7 +1900,8 @@ const result = await nearWallet.signDelegateActions({
 
 near.print({
   count: result.signedDelegateActions.length,
-  first_delegate_hash: result.signedDelegateActions[0]?.delegateHash,
+  first_delegate_borsh_base64:
+    result.signedDelegateActions[0]?.borshSerializedBase64,
 });
 ```
 
@@ -1937,7 +1940,8 @@ const result = await nearWallet.signDelegateActions({
 
 near.print({
   count: result.signedDelegateActions.length,
-  first_delegate_hash: result.signedDelegateActions[0]?.delegateHash,
+  first_delegate_borsh_base64:
+    result.signedDelegateActions[0]?.borshSerializedBase64,
 });
 ```
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -311,14 +311,14 @@ printf 'block_hash=%s\nstorage_usage=%s\n' "$BLOCK_HASH" "$STORAGE_USAGE"
 - Authorization: NEP-366 SignedDelegate; asset: NEP-141 fungible tokens.
 - Browser global: `nearX402`.
 - Runtime: Package-only; not included in agents.js or near.js.
-- Browser status: Preview: requires a compatible upcoming near-connect release and a wallet that advertises timeout-aware delegate signing; the currently published wallet bridge is not production-compatible.
+- Browser status: Beta: requires @fastnear/near-connect 0.13+ and a wallet that advertises both timeout-aware delegate-signing capabilities; production wallet manifest activation remains QA-gated.
 - Required wallet features: `signDelegateActions` and `signDelegateActionsWithTtl`.
 - Package guide: [https://github.com/fastnear/js-monorepo/blob/main/packages/x402/README.md](https://github.com/fastnear/js-monorepo/blob/main/packages/x402/README.md).
 
 ### Choose by task
 
 - Pay an x402 URL from Node.js: `createLocalNearSigner` + `createNearPaymentFetch` from `@fastnear/x402/node` and `@fastnear/x402` — stable core path.
-- Pay an x402 URL from a browser wallet: `createFastNearWalletSigner` + `createNearPaymentFetch` from `@fastnear/wallet` and `@fastnear/x402` — preview until the timeout-aware wallet bridge ships.
+- Pay an x402 URL from a browser wallet: `createFastNearWalletSigner` + `createNearPaymentFetch` from `@fastnear/wallet` and `@fastnear/x402` — beta until Intear and Meteor production wallet QA pass.
 - Protect a seller resource: `createNearResourceServer` from `@fastnear/x402/server` — requires an explicit facilitator.
 - Operate a NEAR facilitator: `createNearFacilitator` from `@fastnear/x402/facilitator` — HTTP framework and secret storage are operator choices.
 - Integrate below the paid-fetch helper: `createNearX402Client` from `@fastnear/x402` — lower-level client path.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8,6 +8,7 @@ Prefer `recipes/index.json` when you need structured task data.
 - `@fastnear/wallet`: wallet connection and transaction/signing provider
 - `@fastnear/utils`: units, crypto, serialization, storage helpers
 - `@fastnear/ml-dsa-65`: opt-in protocol-v85 ML-DSA-65 account-key generation, encoding, hashing, and transaction signing
+- `@fastnear/x402`: official x402 v2 NEAR adapters for paid fetch, local-key clients, resource servers, and facilitators
 
 ## Unified config
 
@@ -261,7 +262,7 @@ Indexed key-value history for exact keys, predecessor scans, and account-scoped 
 - `nearWallet.connect` / `disconnect` / `restore`: open, close, or rehydrate a session per network. `connect({ network, contractId, manifest })` is the canonical entrypoint; `contractId` mints a function-call key scoped to that contract so zero-deposit calls sign silently.
 - `nearWallet.sendTransaction({ receiverId, actions, network })` / `sendTransactions`: dispatch one or many transactions through the connected wallet on the chosen network.
 - `nearWallet.signMessage({ message, recipient, nonce, network })`: NEP-413 message signing.
-- `nearWallet.signDelegateActions({ delegateActions, signerId?, network? })`: sign NEP-366 delegate actions for gasless relay-based flows. Returns `{ signedDelegateActions: Array<{ delegateHash: Uint8Array; signedDelegate: SignedDelegate }> }`.
+- `nearWallet.signDelegateActions({ delegateActions, signerId?, network? })`: sign NEP-366 delegate actions for gasless relay-based flows. Each request may include `blockHeightTtl`; using it requires a wallet that advertises `signDelegateActionsWithTtl`. The canonical transport result is `{ borshSerializedBase64: string }`, while legacy structured and bare-base64 results remain accepted during the bridge transition.
 - `nearWallet.addFunctionCallKey({ contractId, methodNames, allowance, network })` (`@fastnear/wallet@1.1.4+`): grant a second function-call key on another contract after sign-in, so a follow-on zero-deposit call to that contract also signs silently.
 - `nearWallet.accountId` / `isConnected` / `connectedNetworks` / `switchNetwork`: per-network session inspection and the active-network cursor.
 - `nearWallet.onConnect` / `onDisconnect`: subscribe to session lifecycle.
@@ -300,6 +301,92 @@ BLOCK_HASH="$(printf '%s\n' "$ACCOUNT_SUMMARY" | jq -r '.block_hash')"
 STORAGE_USAGE="$(printf '%s\n' "$ACCOUNT_SUMMARY" | jq -r '.storage_usage')"
 
 printf 'block_hash=%s\nstorage_usage=%s\n' "$BLOCK_HASH" "$STORAGE_USAGE"
+```
+
+## x402 payments on NEAR
+
+`@fastnear/x402` adapts the official x402 Foundation NEAR mechanism without introducing another wire format.
+
+- Protocol: x402 v2 `exact` on `near:mainnet` and `near:testnet`.
+- Authorization: NEP-366 SignedDelegate; asset: NEP-141 fungible tokens.
+- Browser global: `nearX402`.
+- Runtime: Package-only; not included in agents.js or near.js.
+- Browser status: Preview: requires a compatible upcoming near-connect release and a wallet that advertises timeout-aware delegate signing; the currently published wallet bridge is not production-compatible.
+- Required wallet features: `signDelegateActions` and `signDelegateActionsWithTtl`.
+- Package guide: [https://github.com/fastnear/js-monorepo/blob/main/packages/x402/README.md](https://github.com/fastnear/js-monorepo/blob/main/packages/x402/README.md).
+
+### Choose by task
+
+- Pay an x402 URL from Node.js: `createLocalNearSigner` + `createNearPaymentFetch` from `@fastnear/x402/node` and `@fastnear/x402` — stable core path.
+- Pay an x402 URL from a browser wallet: `createFastNearWalletSigner` + `createNearPaymentFetch` from `@fastnear/wallet` and `@fastnear/x402` — preview until the timeout-aware wallet bridge ships.
+- Protect a seller resource: `createNearResourceServer` from `@fastnear/x402/server` — requires an explicit facilitator.
+- Operate a NEAR facilitator: `createNearFacilitator` from `@fastnear/x402/facilitator` — HTTP framework and secret storage are operator choices.
+- Integrate below the paid-fetch helper: `createNearX402Client` from `@fastnear/x402` — lower-level client path.
+
+### Entrypoints
+
+- `@fastnear/x402`: `createFastNearWalletSigner`, `createNearX402Client`, `createNearPaymentFetch` — injected FastNEAR wallet signer, NEAR-only x402 client, and paid fetch.
+- `@fastnear/x402/node`: `createLocalNearSigner` — official RPC-backed local full-access-key signer.
+- `@fastnear/x402/server`: `createNearResourceServer` — resource server with one or more explicitly configured facilitators.
+- `@fastnear/x402/facilitator`: `createNearFacilitator` — self-hosted facilitator registration for concrete NEAR networks.
+
+### Constraints
+
+- Only x402 v2 exact payments on near:mainnet and near:testnet are supported.
+- Payments use NEP-141 tokens; native NEAR is not a direct payment asset.
+- Wallet and local-key payers require full-access keys, and recipients need token storage registration.
+- Resource servers require an explicit facilitator; no x402.org or other default is selected.
+- Browser wallet access is injected explicitly and payment occurs only when the application calls the paid fetch function.
+
+### Safe defaults
+
+- Pin near:testnet during development and a concrete NEAR network in production; use near:* only for an intentionally cross-network client.
+- Keep payer and relayer secret keys in server-side secret storage, never browser code.
+- String and number seller prices use the official USDC contract; wNEAR and custom tokens require an explicit { amount, asset } price.
+- Always configure a facilitator explicitly.
+
+### Pay an x402 URL from Node.js
+
+Quickstart ID: `x402-node-paid-fetch`
+
+Use the upstream local full-access-key signer with the high-level paid-fetch helper.
+
+```js
+import { createNearPaymentFetch } from "@fastnear/x402";
+import { createLocalNearSigner } from "@fastnear/x402/node";
+
+const { NEAR_PAYER_ACCOUNT_ID, NEAR_PAYER_SECRET_KEY, X402_RESOURCE_URL } = process.env;
+if (!NEAR_PAYER_ACCOUNT_ID || !NEAR_PAYER_SECRET_KEY || !X402_RESOURCE_URL) {
+  throw new Error("NEAR_PAYER_ACCOUNT_ID, NEAR_PAYER_SECRET_KEY, and X402_RESOURCE_URL are required");
+}
+
+const signer = createLocalNearSigner({
+  accountId: NEAR_PAYER_ACCOUNT_ID,
+  secretKey: NEAR_PAYER_SECRET_KEY,
+  rpcUrls: { "near:testnet": "https://rpc.testnet.fastnear.com" },
+});
+const paidFetch = createNearPaymentFetch({ signer, network: "near:testnet" });
+const response = await paidFetch(X402_RESOURCE_URL);
+if (!response.ok) throw new Error(`Paid request failed: ${response.status}`);
+console.log(await response.json());
+```
+
+### Configure a seller with an explicit remote facilitator
+
+Quickstart ID: `x402-remote-facilitator-seller`
+
+Create the NEAR resource-server core, then pass it to the x402 HTTP framework adapter you choose.
+
+```js
+import { createNearResourceServer } from "@fastnear/x402/server";
+
+const { X402_FACILITATOR_URL } = process.env;
+if (!X402_FACILITATOR_URL) throw new Error("X402_FACILITATOR_URL is required");
+
+export const resourceServer = createNearResourceServer({
+  facilitators: { url: X402_FACILITATOR_URL },
+});
+await resourceServer.initialize();
 ```
 
 ## ML-DSA-65 account-key quickstarts

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -311,14 +311,14 @@ printf 'block_hash=%s\nstorage_usage=%s\n' "$BLOCK_HASH" "$STORAGE_USAGE"
 - Authorization: NEP-366 SignedDelegate; asset: NEP-141 fungible tokens.
 - Browser global: `nearX402`.
 - Runtime: Package-only; not included in agents.js or near.js.
-- Browser status: Beta: requires @fastnear/near-connect 0.13+ and a wallet that advertises both timeout-aware delegate-signing capabilities; production wallet manifest activation remains QA-gated.
+- Browser status: Stable with tested Meteor Wallet support; other wallets must advertise both timeout-aware delegate-signing capabilities and pass the x402 testnet harness before being documented as compatible.
 - Required wallet features: `signDelegateActions` and `signDelegateActionsWithTtl`.
 - Package guide: [https://github.com/fastnear/js-monorepo/blob/main/packages/x402/README.md](https://github.com/fastnear/js-monorepo/blob/main/packages/x402/README.md).
 
 ### Choose by task
 
-- Pay an x402 URL from Node.js: `createLocalNearSigner` + `createNearPaymentFetch` from `@fastnear/x402/node` and `@fastnear/x402` — stable core path.
-- Pay an x402 URL from a browser wallet: `createFastNearWalletSigner` + `createNearPaymentFetch` from `@fastnear/wallet` and `@fastnear/x402` — beta until Intear and Meteor production wallet QA pass.
+- Pay an x402 URL from Node.js: `createLocalNearSigner` + `createNearPaymentFetch` from `@fastnear/x402/node` and `@fastnear/x402` — stable.
+- Pay an x402 URL from a browser wallet: `createFastNearWalletSigner` + `createNearPaymentFetch` from `@fastnear/wallet` and `@fastnear/x402` — stable with a compatible timeout-aware wallet; Meteor Wallet is the tested production path.
 - Protect a seller resource: `createNearResourceServer` from `@fastnear/x402/server` — requires an explicit facilitator.
 - Operate a NEAR facilitator: `createNearFacilitator` from `@fastnear/x402/facilitator` — HTTP framework and secret storage are operator choices.
 - Integrate below the paid-fetch helper: `createNearX402Client` from `@fastnear/x402` — lower-level client path.

--- a/llms.txt
+++ b/llms.txt
@@ -7,6 +7,7 @@ Primary packages:
 - @fastnear/wallet
 - @fastnear/utils
 - @fastnear/ml-dsa-65
+- @fastnear/x402
 
 Low-level-first runtime surfaces:
 - near.config({ apiKey })
@@ -54,7 +55,7 @@ Wallet runtime surfaces (@fastnear/wallet):
 - nearWallet.sendTransaction({ receiverId, actions, network })
 - nearWallet.sendTransactions({ transactions, network })
 - nearWallet.signMessage({ message, recipient, nonce, network })
-- nearWallet.signDelegateActions({ delegateActions, signerId, network })
+- nearWallet.signDelegateActions({ delegateActions: [{ ..., blockHeightTtl }], signerId, network }) — timeout-aware requests require signDelegateActionsWithTtl
 - nearWallet.addFunctionCallKey({ contractId, methodNames, allowance, network })
 - nearWallet.accountId({ network })
 - nearWallet.isConnected({ network })
@@ -62,6 +63,19 @@ Wallet runtime surfaces (@fastnear/wallet):
 - nearWallet.switchNetwork(network)
 - nearWallet.onConnect(handler)
 - nearWallet.onDisconnect(handler)
+
+x402 payment surface (@fastnear/x402):
+- Runtime: Package-only; not included in agents.js or near.js.
+- Protocol: x402 v2 exact; networks: near:mainnet, near:testnet; asset: NEP-141 fungible tokens
+- Pay a URL in Node: createLocalNearSigner + createNearPaymentFetch (@fastnear/x402/node + @fastnear/x402)
+- Protect a seller resource: createNearResourceServer (@fastnear/x402/server); explicit facilitator required
+- Browser: createFastNearWalletSigner / createNearX402Client / createNearPaymentFetch (global nearX402)
+- Node: @fastnear/x402/node createLocalNearSigner
+- Seller: @fastnear/x402/server createNearResourceServer; explicit facilitator required
+- Self-hosted facilitator: @fastnear/x402/facilitator createNearFacilitator
+- Wallet features: signDelegateActions + signDelegateActionsWithTtl
+- Status: Preview: requires a compatible upcoming near-connect release and a wallet that advertises timeout-aware delegate signing; the currently published wallet bridge is not production-compatible.
+- Guide: https://github.com/fastnear/js-monorepo/blob/main/packages/x402/README.md
 
 Named endpoint response types:
 - FastNearRecipeDiscoveryEntry

--- a/llms.txt
+++ b/llms.txt
@@ -74,7 +74,7 @@ x402 payment surface (@fastnear/x402):
 - Seller: @fastnear/x402/server createNearResourceServer; explicit facilitator required
 - Self-hosted facilitator: @fastnear/x402/facilitator createNearFacilitator
 - Wallet features: signDelegateActions + signDelegateActionsWithTtl
-- Status: Beta: requires @fastnear/near-connect 0.13+ and a wallet that advertises both timeout-aware delegate-signing capabilities; production wallet manifest activation remains QA-gated.
+- Status: Stable with tested Meteor Wallet support; other wallets must advertise both timeout-aware delegate-signing capabilities and pass the x402 testnet harness before being documented as compatible.
 - Guide: https://github.com/fastnear/js-monorepo/blob/main/packages/x402/README.md
 
 Named endpoint response types:

--- a/llms.txt
+++ b/llms.txt
@@ -74,7 +74,7 @@ x402 payment surface (@fastnear/x402):
 - Seller: @fastnear/x402/server createNearResourceServer; explicit facilitator required
 - Self-hosted facilitator: @fastnear/x402/facilitator createNearFacilitator
 - Wallet features: signDelegateActions + signDelegateActionsWithTtl
-- Status: Preview: requires a compatible upcoming near-connect release and a wallet that advertises timeout-aware delegate signing; the currently published wallet bridge is not production-compatible.
+- Status: Beta: requires @fastnear/near-connect 0.13+ and a wallet that advertises both timeout-aware delegate-signing capabilities; production wallet manifest activation remains QA-gated.
 - Guide: https://github.com/fastnear/js-monorepo/blob/main/packages/x402/README.md
 
 Named endpoint response types:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastnear-js-monorepo",
-  "version": "1.4.0",
+  "version": "1.5.0-beta.0",
   "description": "Easily interact with the NEAR Protocol blockchain",
   "scripts": {
     "type-check": "yarn workspaces foreach --all -t run type-check",
@@ -44,7 +44,7 @@
     "packages/*"
   ],
   "dependencies": {
-    "@fastnear/near-connect": "^0.12.1",
+    "@fastnear/near-connect": "^0.13.0",
     "@near-js/transactions": "^2.5.1",
     "@noble/curves": "=2.0.1",
     "@noble/hashes": "=2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastnear-js-monorepo",
-  "version": "1.5.0-beta.0",
+  "version": "1.5.0-beta.1",
   "description": "Easily interact with the NEAR Protocol blockchain",
   "scripts": {
     "type-check": "yarn workspaces foreach --all -t run type-check",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "bench:ml-dsa-65": "yarn workspace @fastnear/ml-dsa-65 bench",
     "smoke:ml-dsa:testnet": "yarn build && node scripts/smoke-ml-dsa-testnet.mjs",
     "smoke:x402:testnet": "yarn build && node scripts/smoke-x402-testnet.mjs",
+    "smoke:x402:published": "node scripts/verify-published-x402.mjs",
     "smoke:services:live": "yarn workspace @fastnear/api build && node scripts/smoke-services-live.mjs",
     "smoke:agent:published": "node scripts/smoke-published-agent-surfaces.mjs",
     "test": "vitest run && yarn test:agent"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "check:bundles": "node scripts/check-bundle-sizes.mjs",
     "bench:ml-dsa-65": "yarn workspace @fastnear/ml-dsa-65 bench",
     "smoke:ml-dsa:testnet": "yarn build && node scripts/smoke-ml-dsa-testnet.mjs",
+    "smoke:x402:testnet": "yarn build && node scripts/smoke-x402-testnet.mjs",
     "smoke:services:live": "yarn workspace @fastnear/api build && node scripts/smoke-services-live.mjs",
     "smoke:agent:published": "node scripts/smoke-published-agent-surfaces.mjs",
     "test": "vitest run && yarn test:agent"
@@ -43,10 +44,15 @@
   ],
   "dependencies": {
     "@fastnear/near-connect": "^0.12.1",
+    "@near-js/transactions": "^2.5.1",
     "@noble/curves": "=2.0.1",
     "@noble/hashes": "=2.0.1",
     "@noble/post-quantum": "=0.6.0",
+    "@noble/secp256k1": "^3.1.0",
     "@walletconnect/sign-client": "^2.23.7",
+    "@x402/core": "~2.18.0",
+    "@x402/fetch": "~2.18.0",
+    "@x402/near": "~2.18.0",
     "base58-js": "=2.0.0",
     "events": "^3.3.0",
     "js-base64": "^3.7.7"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "@noble/curves": "=2.0.1",
     "@noble/hashes": "=2.0.1",
     "@noble/post-quantum": "=0.6.0",
-    "@noble/secp256k1": "^3.1.0",
     "@walletconnect/sign-client": "^2.23.7",
     "@x402/core": "~2.18.0",
     "@x402/fetch": "~2.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastnear-js-monorepo",
-  "version": "1.5.0-beta.1",
+  "version": "1.5.0",
   "description": "Easily interact with the NEAR Protocol blockchain",
   "scripts": {
     "type-check": "yarn workspaces foreach --all -t run type-check",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/api",
-  "version": "1.5.0-beta.1",
+  "version": "1.5.0",
   "description": "Interact with NEAR Protocol blockchain including transaction signing, utilities, and more.",
   "type": "module",
   "types": "./dist/esm/index.d.ts",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/api",
-  "version": "1.5.0-beta.0",
+  "version": "1.5.0-beta.1",
   "description": "Interact with NEAR Protocol blockchain including transaction signing, utilities, and more.",
   "type": "module",
   "types": "./dist/esm/index.d.ts",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/api",
-  "version": "1.4.0",
+  "version": "1.5.0-beta.0",
   "description": "Interact with NEAR Protocol blockchain including transaction signing, utilities, and more.",
   "type": "module",
   "types": "./dist/esm/index.d.ts",

--- a/packages/borsh-schema/package.json
+++ b/packages/borsh-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/borsh-schema",
-  "version": "1.5.0-beta.0",
+  "version": "1.5.0-beta.1",
   "description": "NEAR Protocol's borsh schema for common applications",
   "type": "module",
   "types": "./dist/esm/index.d.ts",

--- a/packages/borsh-schema/package.json
+++ b/packages/borsh-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/borsh-schema",
-  "version": "1.5.0-beta.1",
+  "version": "1.5.0",
   "description": "NEAR Protocol's borsh schema for common applications",
   "type": "module",
   "types": "./dist/esm/index.d.ts",

--- a/packages/borsh-schema/package.json
+++ b/packages/borsh-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/borsh-schema",
-  "version": "1.4.0",
+  "version": "1.5.0-beta.0",
   "description": "NEAR Protocol's borsh schema for common applications",
   "type": "module",
   "types": "./dist/esm/index.d.ts",

--- a/packages/borsh/package.json
+++ b/packages/borsh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/borsh",
-  "version": "1.5.0-beta.0",
+  "version": "1.5.0-beta.1",
   "description": "Lean borsh serializer/deserializer for NEAR Protocol",
   "license": "MIT",
   "type": "module",

--- a/packages/borsh/package.json
+++ b/packages/borsh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/borsh",
-  "version": "1.4.0",
+  "version": "1.5.0-beta.0",
   "description": "Lean borsh serializer/deserializer for NEAR Protocol",
   "license": "MIT",
   "type": "module",

--- a/packages/borsh/package.json
+++ b/packages/borsh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/borsh",
-  "version": "1.5.0-beta.1",
+  "version": "1.5.0",
   "description": "Lean borsh serializer/deserializer for NEAR Protocol",
   "license": "MIT",
   "type": "module",

--- a/packages/ml-dsa-65/package.json
+++ b/packages/ml-dsa-65/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/ml-dsa-65",
-  "version": "1.5.0-beta.0",
+  "version": "1.5.0-beta.1",
   "description": "Opt-in ML-DSA-65 access-key and transaction-signing support for NEAR Protocol",
   "license": "MIT",
   "type": "module",

--- a/packages/ml-dsa-65/package.json
+++ b/packages/ml-dsa-65/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/ml-dsa-65",
-  "version": "1.4.0",
+  "version": "1.5.0-beta.0",
   "description": "Opt-in ML-DSA-65 access-key and transaction-signing support for NEAR Protocol",
   "license": "MIT",
   "type": "module",

--- a/packages/ml-dsa-65/package.json
+++ b/packages/ml-dsa-65/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/ml-dsa-65",
-  "version": "1.5.0-beta.1",
+  "version": "1.5.0",
   "description": "Opt-in ML-DSA-65 access-key and transaction-signing support for NEAR Protocol",
   "license": "MIT",
   "type": "module",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/utils",
-  "version": "1.5.0-beta.1",
+  "version": "1.5.0",
   "description": "Utility functions for interactions with the NEAR blockchain",
   "type": "module",
   "types": "./dist/esm/index.d.ts",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/utils",
-  "version": "1.5.0-beta.0",
+  "version": "1.5.0-beta.1",
   "description": "Utility functions for interactions with the NEAR blockchain",
   "type": "module",
   "types": "./dist/esm/index.d.ts",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/utils",
-  "version": "1.4.0",
+  "version": "1.5.0-beta.0",
   "description": "Utility functions for interactions with the NEAR blockchain",
   "type": "module",
   "types": "./dist/esm/index.d.ts",

--- a/packages/wallet-adapter/package.json
+++ b/packages/wallet-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/wallet-adapter",
-  "version": "1.5.0-beta.1",
+  "version": "1.5.0",
   "description": "Wallet adapter implementations for Meteor Wallet and Near Mobile",
   "license": "MIT",
   "type": "module",

--- a/packages/wallet-adapter/package.json
+++ b/packages/wallet-adapter/package.json
@@ -43,6 +43,7 @@
     "@fastnear/borsh": "workspace:*",
     "@fastnear/borsh-schema": "workspace:*",
     "@fastnear/utils": "workspace:*",
+    "@near-js/transactions": "*",
     "@noble/curves": "*"
   },
   "devDependencies": {

--- a/packages/wallet-adapter/package.json
+++ b/packages/wallet-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/wallet-adapter",
-  "version": "1.5.0-beta.0",
+  "version": "1.5.0-beta.1",
   "description": "Wallet adapter implementations for Meteor Wallet and Near Mobile",
   "license": "MIT",
   "type": "module",
@@ -43,7 +43,6 @@
     "@fastnear/borsh": "workspace:*",
     "@fastnear/borsh-schema": "workspace:*",
     "@fastnear/utils": "workspace:*",
-    "@near-js/transactions": "*",
     "@noble/curves": "*"
   },
   "devDependencies": {

--- a/packages/wallet-adapter/package.json
+++ b/packages/wallet-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/wallet-adapter",
-  "version": "1.4.0",
+  "version": "1.5.0-beta.0",
   "description": "Wallet adapter implementations for Meteor Wallet and Near Mobile",
   "license": "MIT",
   "type": "module",

--- a/packages/wallet-adapter/src/delegate-validation.ts
+++ b/packages/wallet-adapter/src/delegate-validation.ts
@@ -5,7 +5,6 @@ import {
   SCHEMA,
   sha256,
 } from "@fastnear/utils";
-import { encodeDelegateAction } from "@near-js/transactions";
 import { ed25519 } from "@noble/curves/ed25519.js";
 import { secp256k1 } from "@noble/curves/secp256k1.js";
 
@@ -30,8 +29,21 @@ function readBytes(value: unknown, key: string, length: number): Uint8Array | nu
   return bytes.length === length ? bytes : null;
 }
 
+// NEP-366 signs delegate actions with a Borsh-serialized actionable-message
+// prefix before the DelegateAction payload. This is the same byte sequence as
+// @near-js/transactions encodeDelegateAction without bundling that package into
+// the wallet-adapter browser build.
+function encodeDelegateActionForSigning(delegateAction: unknown): Uint8Array {
+  const prefix = 2 ** 30 + 366;
+  const delegateBytes = new Uint8Array(serialize(SCHEMA.DelegateAction, delegateAction));
+  const prefixed = new Uint8Array(4 + delegateBytes.length);
+  new DataView(prefixed.buffer).setUint32(0, prefix, true);
+  prefixed.set(delegateBytes, 4);
+  return prefixed;
+}
+
 function verifySignature(signedDelegate: any): boolean {
-  const delegateBytes = encodeDelegateAction(signedDelegate.delegateAction);
+  const delegateBytes = encodeDelegateActionForSigning(signedDelegate.delegateAction);
   const digest = sha256(delegateBytes);
   const edPublicKey = readBytes(signedDelegate.delegateAction?.publicKey, "ed25519Key", 32);
   const edSignature = readBytes(signedDelegate.signature, "ed25519Signature", 64);

--- a/packages/wallet-adapter/src/delegate-validation.ts
+++ b/packages/wallet-adapter/src/delegate-validation.ts
@@ -5,6 +5,7 @@ import {
   SCHEMA,
   sha256,
 } from "@fastnear/utils";
+import { encodeDelegateAction } from "@near-js/transactions";
 import { ed25519 } from "@noble/curves/ed25519.js";
 import { secp256k1 } from "@noble/curves/secp256k1.js";
 
@@ -30,9 +31,7 @@ function readBytes(value: unknown, key: string, length: number): Uint8Array | nu
 }
 
 function verifySignature(signedDelegate: any): boolean {
-  const delegateBytes = new Uint8Array(
-    serialize(SCHEMA.DelegateAction, signedDelegate.delegateAction),
-  );
+  const delegateBytes = encodeDelegateAction(signedDelegate.delegateAction);
   const digest = sha256(delegateBytes);
   const edPublicKey = readBytes(signedDelegate.delegateAction?.publicKey, "ed25519Key", 32);
   const edSignature = readBytes(signedDelegate.signature, "ed25519Signature", 64);

--- a/packages/wallet-adapter/src/meteor-delegate.test.ts
+++ b/packages/wallet-adapter/src/meteor-delegate.test.ts
@@ -5,6 +5,7 @@ import {
   SCHEMA,
   sha256,
 } from "@fastnear/utils";
+import { encodeDelegateAction } from "@near-js/transactions";
 import { ed25519 } from "@noble/curves/ed25519.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { validateSignedDelegate } from "./delegate-validation.js";
@@ -53,9 +54,7 @@ function signDelegateAction(
   };
   delegateAction.nonce = 1n;
   mutate?.(delegateAction);
-  const digest = sha256(
-    new Uint8Array(serialize(SCHEMA.DelegateAction, delegateAction)),
-  );
+  const digest = sha256(encodeDelegateAction(delegateAction));
   const signedDelegate = {
     delegateAction,
     signature: {

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/wallet",
-  "version": "1.4.0",
+  "version": "1.5.0-beta.0",
   "description": "Multi-wallet connector for NEAR dApps — MyNearWallet, HERE, Meteor, and more",
   "license": "MIT",
   "type": "module",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/wallet",
-  "version": "1.5.0-beta.1",
+  "version": "1.5.0",
   "description": "Multi-wallet connector for NEAR dApps — MyNearWallet, HERE, Meteor, and more",
   "license": "MIT",
   "type": "module",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/wallet",
-  "version": "1.5.0-beta.0",
+  "version": "1.5.0-beta.1",
   "description": "Multi-wallet connector for NEAR dApps — MyNearWallet, HERE, Meteor, and more",
   "license": "MIT",
   "type": "module",

--- a/packages/wallet/src/connector.test.ts
+++ b/packages/wallet/src/connector.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const wallets = new Map<string, any>();
+
+vi.mock("@fastnear/near-connect", () => {
+  class NearConnector {
+    availableWallets = Array.from(wallets.values()).map((wallet) => ({
+      manifest: wallet.manifest,
+    }));
+    whenManifestLoaded = Promise.resolve();
+
+    async connect({ walletId }: { walletId?: string } = {}) {
+      const selectedWallet =
+        wallets.get(walletId ?? "") ?? Array.from(wallets.values())[0];
+      if (!selectedWallet) throw new Error("No mocked wallet");
+      return selectedWallet;
+    }
+
+    async getConnectedWallet() {
+      return {
+        accounts: [{ accountId: "mike.testnet", publicKey: "ed25519:test" }],
+        wallet: Array.from(wallets.values())[0],
+      };
+    }
+
+    on() {
+      // The wallet wrapper falls back to getConnectedWallet() in these tests.
+    }
+  }
+
+  return { NearConnector };
+});
+
+describe("walletName", () => {
+  afterEach(async () => {
+    wallets.clear();
+    const connector = await import("./connector.js");
+    connector.reset();
+  });
+
+  it("falls back to near-connect manifest names for sandbox wallets", async () => {
+    wallets.set("meteor-wallet", {
+      manifest: { id: "meteor-wallet", name: "Meteor Wallet" },
+      signOut: vi.fn(),
+    });
+
+    const connector = await import("./connector.js");
+    await connector.connect({ network: "testnet", walletId: "meteor-wallet" });
+
+    expect(connector.walletName({ network: "testnet" })).toBe("Meteor Wallet");
+  });
+
+  it("prefers metadata names when wallets expose both shapes", async () => {
+    wallets.set("meteor-wallet", {
+      manifest: { id: "meteor-wallet", name: "Meteor Wallet" },
+      metadata: { name: "Meteor Metadata" },
+      signOut: vi.fn(),
+    });
+
+    const connector = await import("./connector.js");
+    await connector.connect({ network: "testnet", walletId: "meteor-wallet" });
+
+    expect(connector.walletName({ network: "testnet" })).toBe("Meteor Metadata");
+  });
+});

--- a/packages/wallet/src/connector.ts
+++ b/packages/wallet/src/connector.ts
@@ -485,7 +485,11 @@ export function getActiveNetwork(): Network {
 export function walletName(opts?: { network?: Network }): string | null {
   const s = stateFor(opts?.network);
   if (!s.connectedWallet) return null;
-  return (s.connectedWallet as NearWalletBase & { metadata?: { name?: string } }).metadata?.name ?? null;
+  const wallet = s.connectedWallet as NearWalletBase & {
+    manifest?: { name?: string };
+    metadata?: { name?: string };
+  };
+  return wallet.metadata?.name ?? wallet.manifest?.name ?? null;
 }
 
 /**

--- a/packages/x402/README.md
+++ b/packages/x402/README.md
@@ -4,7 +4,7 @@ Adapters for using the official [`@x402/near`](https://www.npmjs.com/package/@x4
 
 This package does not implement a second x402 wire format. It uses x402 v2, NEP-366 signed delegate actions, and the Foundation's NEAR verifier and settlement code.
 
-> **Browser-wallet preview:** the wallet path requires a compatible `@fastnear/near-connect` release and a wallet that advertises both `signDelegateActions` and `signDelegateActionsWithTtl`. That bridge is not yet available in the currently published wallet stack. Until those releases land, use the local-key client for integration work and do not present the browser example as production-ready.
+> **Browser-wallet beta:** the wallet path requires `@fastnear/near-connect@0.13.0` or later and a wallet that advertises both `signDelegateActions` and `signDelegateActionsWithTtl`. Keep production rollout gated on successful Intear and Meteor testnet settlement QA; the local-key client is the stable integration path today.
 
 ## Install
 
@@ -71,7 +71,7 @@ Use `network: "near:*"` (the default) when the client should accept either canon
 
 ### Browser script
 
-The IIFE bundle exports `window.nearX402`. The `@next` URLs below intentionally describe the preview channel; pin released versions before production use.
+The IIFE bundle exports `window.nearX402`. The `@next` URLs below intentionally describe the beta channel; pin exact released versions before production use.
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@fastnear/wallet@next/dist/umd/browser.global.js"></script>
@@ -289,9 +289,9 @@ This is an in-process trust boundary: isolate the facilitator behind authenticat
 
 ## Release gate
 
-The browser path must be released in dependency order. From the current `1.3.x` line, first publish the Meteor bridge in the synchronized FastNEAR `1.4.0` release without publishing `@fastnear/x402`. Then publish `@fastnear/near-connect@0.13.0` with the Meteor executor, Intear TTL forwarding, and both capability flags. Only after `@fastnear/wallet` consumes that release should this package enter the synchronized `1.5.0-beta.0` prerelease.
+The browser path is released in dependency order. FastNEAR `1.4.0` shipped the timeout-aware wallet prerequisite without `@fastnear/x402`; `@fastnear/near-connect@0.13.0` now carries the Meteor executor, Intear TTL forwarding, and shared delegate-signing capability types. The synchronized `1.5.0-beta.0` prerelease consumes that bridge and adds `@fastnear/x402`.
 
-Promote the beta only after real testnet approval and settlement succeed through both Intear and Meteor, an automated local-key testnet flow succeeds, packed CJS/ESM subpath imports pass, and the jsDelivr IIFE exposes the locked `nearX402` global. If repository versions move first, use the next two synchronized minor versions in the same prerequisite-then-feature order.
+Promote the beta only after real testnet approval and settlement succeed through both Intear and Meteor production wallet paths, an automated local-key testnet flow succeeds, packed CJS/ESM subpath imports pass, and the jsDelivr IIFE exposes the locked `nearX402` global. If repository versions move first, use the next two synchronized minor versions in the same prerequisite-then-feature order.
 
 Repository maintainers should use the [guarded testnet QA guide](https://github.com/fastnear/js-monorepo/blob/main/packages/x402/TESTNET_QA.md) for the shared local-key and browser-wallet release harness.
 

--- a/packages/x402/README.md
+++ b/packages/x402/README.md
@@ -4,7 +4,7 @@ Adapters for using the official [`@x402/near`](https://www.npmjs.com/package/@x4
 
 This package does not implement a second x402 wire format. It uses x402 v2, NEP-366 signed delegate actions, and the Foundation's NEAR verifier and settlement code.
 
-> **Browser-wallet beta:** the wallet path requires `@fastnear/near-connect@0.13.0` or later and a wallet that advertises both `signDelegateActions` and `signDelegateActionsWithTtl`. Keep production rollout gated on successful Intear and Meteor testnet settlement QA; the local-key client is the stable integration path today.
+> **Browser-wallet support:** the wallet path requires `@fastnear/near-connect@0.13.0` or later and a wallet that advertises both `signDelegateActions` and `signDelegateActionsWithTtl`. Meteor Wallet is the tested production wallet path for this release; additional wallets should pass the same guarded testnet harness before being documented as compatible.
 
 ## Install
 
@@ -24,8 +24,8 @@ Choose the smallest entrypoint for the job:
 
 | Task | Imports | Main factory | Status |
 |---|---|---|---|
-| Pay a URL from Node.js | `@fastnear/x402`, `@fastnear/x402/node` | `createNearPaymentFetch` | Stable core path |
-| Pay from a browser wallet | `@fastnear/x402`, `@fastnear/wallet` | `createFastNearWalletSigner` + `createNearPaymentFetch` | Preview |
+| Pay a URL from Node.js | `@fastnear/x402`, `@fastnear/x402/node` | `createNearPaymentFetch` | Stable |
+| Pay from a browser wallet | `@fastnear/x402`, `@fastnear/wallet` | `createFastNearWalletSigner` + `createNearPaymentFetch` | Stable with a compatible timeout-aware wallet |
 | Protect a seller resource | `@fastnear/x402/server` | `createNearResourceServer` | Explicit facilitator required |
 | Operate a facilitator | `@fastnear/x402/facilitator` | `createNearFacilitator` | Bring your own HTTP framework |
 
@@ -71,11 +71,11 @@ Use `network: "near:*"` (the default) when the client should accept either canon
 
 ### Browser script
 
-The IIFE bundle exports `window.nearX402`. The `@next` URLs below intentionally describe the beta channel; pin exact released versions before production use.
+The IIFE bundle exports `window.nearX402`. Pin exact released versions for production use.
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@fastnear/wallet@next/dist/umd/browser.global.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/@fastnear/x402@next/dist/umd/browser.global.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@fastnear/wallet@1.5.0/dist/umd/browser.global.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@fastnear/x402@1.5.0/dist/umd/browser.global.js"></script>
 <script>
   async function payAfterClick(url) {
     const connection = await nearWallet.connect({
@@ -289,9 +289,9 @@ This is an in-process trust boundary: isolate the facilitator behind authenticat
 
 ## Release gate
 
-The browser path is released in dependency order. FastNEAR `1.4.0` shipped the timeout-aware wallet prerequisite without `@fastnear/x402`; `@fastnear/near-connect@0.13.0` now carries the Meteor executor, Intear TTL forwarding, and shared delegate-signing capability types. The synchronized `1.5.0-beta.0` prerelease consumes that bridge and adds `@fastnear/x402`.
+The browser path was released in dependency order. FastNEAR `1.4.0` shipped the timeout-aware wallet prerequisite without `@fastnear/x402`; `@fastnear/near-connect@0.13.0` carries shared delegate-signing capability types and the Meteor bridge; FastNEAR `1.5.0` adds the stable `@fastnear/x402` package.
 
-Promote the beta only after real testnet approval and settlement succeed through both Intear and Meteor production wallet paths, an automated local-key testnet flow succeeds, packed CJS/ESM subpath imports pass, and the jsDelivr IIFE exposes the locked `nearX402` global. If repository versions move first, use the next two synchronized minor versions in the same prerequisite-then-feature order.
+Stable release requires an automated local-key testnet flow, one real Meteor Wallet testnet settlement from `mike.testnet`, packed CJS/ESM subpath imports, bundle-budget checks, generated-agent consistency, and jsDelivr verification that the IIFE exposes the locked `nearX402` global. Other wallets are not release gates unless they are actively maintained, advertise `signDelegateActionsWithTtl`, and pass the same one-click settlement harness.
 
 Repository maintainers should use the [guarded testnet QA guide](https://github.com/fastnear/js-monorepo/blob/main/packages/x402/TESTNET_QA.md) for the shared local-key and browser-wallet release harness.
 

--- a/packages/x402/README.md
+++ b/packages/x402/README.md
@@ -1,0 +1,302 @@
+# `@fastnear/x402`
+
+Adapters for using the official [`@x402/near`](https://www.npmjs.com/package/@x402/near) exact-payment mechanism with FastNEAR wallets, paid HTTP clients, resource servers, and facilitators.
+
+This package does not implement a second x402 wire format. It uses x402 v2, NEP-366 signed delegate actions, and the Foundation's NEAR verifier and settlement code.
+
+> **Browser-wallet preview:** the wallet path requires a compatible `@fastnear/near-connect` release and a wallet that advertises both `signDelegateActions` and `signDelegateActionsWithTtl`. That bridge is not yet available in the currently published wallet stack. Until those releases land, use the local-key client for integration work and do not present the browser example as production-ready.
+
+## Install
+
+For local-key, resource-server, or facilitator use:
+
+```bash
+npm install @fastnear/x402
+```
+
+For the browser-wallet client:
+
+```bash
+npm install @fastnear/x402 @fastnear/wallet
+```
+
+Choose the smallest entrypoint for the job:
+
+| Task | Imports | Main factory | Status |
+|---|---|---|---|
+| Pay a URL from Node.js | `@fastnear/x402`, `@fastnear/x402/node` | `createNearPaymentFetch` | Stable core path |
+| Pay from a browser wallet | `@fastnear/x402`, `@fastnear/wallet` | `createFastNearWalletSigner` + `createNearPaymentFetch` | Preview |
+| Protect a seller resource | `@fastnear/x402/server` | `createNearResourceServer` | Explicit facilitator required |
+| Operate a facilitator | `@fastnear/x402/facilitator` | `createNearFacilitator` | Bring your own HTTP framework |
+
+`createNearX402Client` is the lower-level client factory for custom integrations. x402 is package-only: it is not exposed as `near.x402` or `near.recipes.x402` by `near.js` or `agents.js`.
+
+Install the HTTP framework adapter separately on the resource-server or facilitator host, for example `@x402/express` and `express`. This package deliberately does not choose a web framework.
+
+## Browser wallet and paid fetch
+
+Wallet access is injected explicitly. Importing `@fastnear/x402` never opens a wallet, signs a payment, or performs a fetch.
+
+```js
+import * as nearWallet from "@fastnear/wallet";
+import {
+  createFastNearWalletSigner,
+  createNearPaymentFetch,
+} from "@fastnear/x402";
+
+const connection = await nearWallet.connect({
+  network: "testnet",
+  features: {
+    signDelegateActions: true,
+    signDelegateActionsWithTtl: true,
+  },
+});
+
+if (!connection) throw new Error("No compatible wallet was connected");
+
+const signer = createFastNearWalletSigner({ wallet: nearWallet });
+const paidFetch = createNearPaymentFetch({
+  signer,
+  network: "near:testnet",
+});
+
+// Call only in response to an explicit user action. A 402 challenge can open
+// the wallet for approval and then retry with the signed payment header.
+const response = await paidFetch("https://seller.example/protected");
+if (!response.ok) throw new Error(`Request failed: ${response.status}`);
+console.log(await response.json());
+```
+
+Use `network: "near:*"` (the default) when the client should accept either canonical NEAR network. Use a concrete network to refuse challenges from the other network.
+
+### Browser script
+
+The IIFE bundle exports `window.nearX402`. The `@next` URLs below intentionally describe the preview channel; pin released versions before production use.
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/@fastnear/wallet@next/dist/umd/browser.global.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@fastnear/x402@next/dist/umd/browser.global.js"></script>
+<script>
+  async function payAfterClick(url) {
+    const connection = await nearWallet.connect({
+      network: "testnet",
+      features: {
+        signDelegateActions: true,
+        signDelegateActionsWithTtl: true,
+      },
+    });
+    if (!connection) throw new Error("No compatible wallet was connected");
+
+    const signer = nearX402.createFastNearWalletSigner({ wallet: nearWallet });
+    const paidFetch = nearX402.createNearPaymentFetch({
+      signer,
+      network: "near:testnet",
+    });
+    return paidFetch(url);
+  }
+</script>
+```
+
+## Node.js local-key client
+
+`@fastnear/x402/node` reuses the official reference signer. The secret key must be a full-access key for `accountId`; function-call keys cannot authorize the delegated token transfer.
+
+```js
+import { createNearPaymentFetch } from "@fastnear/x402";
+import { createLocalNearSigner } from "@fastnear/x402/node";
+
+const signer = createLocalNearSigner({
+  accountId: process.env.NEAR_PAYER_ACCOUNT_ID,
+  secretKey: process.env.NEAR_PAYER_SECRET_KEY,
+  rpcUrls: {
+    "near:testnet": "https://rpc.testnet.fastnear.com",
+  },
+});
+
+const paidFetch = createNearPaymentFetch({
+  signer,
+  network: "near:testnet",
+});
+
+const response = await paidFetch("https://seller.example/protected");
+if (!response.ok) throw new Error(`Paid request failed: ${response.status}`);
+console.log(await response.json());
+```
+
+Keep the payer key in server-side secret storage. Never embed it in browser JavaScript.
+
+## Resource server with an explicit facilitator
+
+`createNearResourceServer` requires at least one facilitator client or URL. There is no implicit x402.org or other default. Confirm that a remote facilitator advertises `exact` on the intended NEAR network before relying on it; the current provider list is maintained in the [x402 facilitator directory](https://docs.x402.org/dev-tools/facilitators).
+
+```js
+import express from "express";
+import { paymentMiddleware } from "@x402/express";
+import { createNearResourceServer } from "@fastnear/x402/server";
+
+const { X402_FACILITATOR_URL, NEAR_PAYMENT_ACCOUNT_ID } = process.env;
+if (!X402_FACILITATOR_URL || !NEAR_PAYMENT_ACCOUNT_ID) {
+  throw new Error("X402_FACILITATOR_URL and NEAR_PAYMENT_ACCOUNT_ID are required");
+}
+
+const resourceServer = createNearResourceServer({
+  facilitators: { url: X402_FACILITATOR_URL },
+});
+
+const app = express();
+app.use(paymentMiddleware({
+  "GET /weather": {
+    accepts: [{
+      scheme: "exact",
+      network: "near:testnet",
+      price: "$0.01",
+      payTo: NEAR_PAYMENT_ACCOUNT_ID,
+    }],
+    description: "Testnet weather report",
+    mimeType: "application/json",
+  },
+}, resourceServer));
+
+app.get("/weather", (_request, response) => {
+  response.json({ weather: "sunny" });
+});
+
+app.listen(4021);
+```
+
+String/number money prices use the official Circle USDC contract for the selected network. To name another NEP-141 token explicitly, use `{ amount: "<smallest-unit amount>", asset: "<token account>" }` as the price. You can also pass `moneyParsers` to centralize custom denomination rules.
+
+For example, price a route in wrapped NEAR by supplying the network's canonical wNEAR token account explicitly; `0.01` wNEAR is `10000000000000000000000` atomic units for a 24-decimal token:
+
+```js
+price: {
+  amount: "10000000000000000000000",
+  asset: process.env.WNEAR_TOKEN_ACCOUNT_ID,
+}
+```
+
+Treat the token account as deployment configuration and verify it for the selected network rather than copying an unverified contract ID.
+
+For an authenticated remote facilitator, pass `createAuthHeaders` beside `url`; it must return header objects for `verify`, `settle`, and `supported`.
+
+## Self-hosted facilitator
+
+The facilitator owns relayer accounts that pay transaction gas and the required yoctoNEAR deposit. Relayer keys are full-access secrets and must never be exposed to clients.
+
+```js
+import express from "express";
+import { createNearFacilitator } from "@fastnear/x402/facilitator";
+
+const { NEAR_RELAYER_ACCOUNT_ID, NEAR_RELAYER_SECRET_KEY } = process.env;
+if (!NEAR_RELAYER_ACCOUNT_ID || !NEAR_RELAYER_SECRET_KEY) {
+  throw new Error("NEAR relayer credentials are required");
+}
+
+const facilitator = createNearFacilitator({
+  registrations: [{
+    network: "near:testnet",
+    signer: {
+      relayers: [{
+        accountId: NEAR_RELAYER_ACCOUNT_ID,
+        secretKey: NEAR_RELAYER_SECRET_KEY,
+      }],
+      rpcUrls: {
+        "near:testnet": "https://rpc.testnet.fastnear.com",
+      },
+    },
+  }],
+});
+
+const app = express();
+app.use(express.json());
+
+app.post("/verify", async (request, response, next) => {
+  try {
+    const { paymentPayload, paymentRequirements } = request.body;
+    response.json(await facilitator.verify(paymentPayload, paymentRequirements));
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.post("/settle", async (request, response, next) => {
+  try {
+    const { paymentPayload, paymentRequirements } = request.body;
+    response.json(await facilitator.settle(paymentPayload, paymentRequirements));
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.get("/supported", (_request, response) => {
+  response.json(facilitator.getSupported());
+});
+
+app.listen(4022);
+```
+
+This is the minimum transport wiring, not a production deployment recipe. Validate request bodies and add authentication, rate limits, observability, durable operational controls, and secret management appropriate to the service.
+
+When the seller and facilitator deliberately run in the same trusted process, no HTTP adapter is needed. The two FastNEAR factories compose directly:
+
+```js
+import { createNearFacilitator } from "@fastnear/x402/facilitator";
+import { createNearResourceServer } from "@fastnear/x402/server";
+
+const { NEAR_RELAYER_ACCOUNT_ID, NEAR_RELAYER_SECRET_KEY } = process.env;
+if (!NEAR_RELAYER_ACCOUNT_ID || !NEAR_RELAYER_SECRET_KEY) {
+  throw new Error("NEAR relayer credentials are required");
+}
+
+const facilitator = createNearFacilitator({
+  registrations: [{
+    network: "near:testnet",
+    signer: {
+      relayers: [{
+        accountId: NEAR_RELAYER_ACCOUNT_ID,
+        secretKey: NEAR_RELAYER_SECRET_KEY,
+      }],
+    },
+  }],
+});
+
+const resourceServer = createNearResourceServer({
+  facilitators: facilitator,
+});
+
+await resourceServer.initialize();
+```
+
+This is an in-process trust boundary: isolate the facilitator behind authenticated HTTP instead when relayer ownership, scaling, or operations belong to a separate service.
+
+## Payment constraints
+
+- Only x402 v2 `exact` payments on `near:mainnet` and `near:testnet` are accepted.
+- Payments transfer NEP-141 fungible tokens. Native NEAR is not a direct payment asset; use an explicit wrapped-NEAR token contract when appropriate.
+- The payer must have enough token balance, and the recipient (`payTo`) must already be registered for storage with the selected token contract.
+- Wallet and local-key signers require a full-access key. The facilitator rejects function-call keys.
+- The payer does not need NEAR for gas. The selected facilitator relayer sponsors the outer transaction gas and 1 yoctoNEAR attached to `ft_transfer`.
+- Browser targets must allow the calling origin through CORS and expose the x402 payment response headers when the client needs to read them.
+
+## Entrypoints
+
+| Import | Purpose |
+|---|---|
+| `@fastnear/x402` | Wallet signer adapter, x402 client, and paid fetch |
+| `@fastnear/x402/node` | Official RPC-backed local-key signer |
+| `@fastnear/x402/server` | NEAR resource server with explicit facilitator configuration |
+| `@fastnear/x402/facilitator` | Self-hostable NEAR facilitator registration |
+
+## Release gate
+
+The browser path must be released in dependency order. From the current `1.3.x` line, first publish the Meteor bridge in the synchronized FastNEAR `1.4.0` release without publishing `@fastnear/x402`. Then publish `@fastnear/near-connect@0.13.0` with the Meteor executor, Intear TTL forwarding, and both capability flags. Only after `@fastnear/wallet` consumes that release should this package enter the synchronized `1.5.0-beta.0` prerelease.
+
+Promote the beta only after real testnet approval and settlement succeed through both Intear and Meteor, an automated local-key testnet flow succeeds, packed CJS/ESM subpath imports pass, and the jsDelivr IIFE exposes the locked `nearX402` global. If repository versions move first, use the next two synchronized minor versions in the same prerequisite-then-feature order.
+
+Repository maintainers should use the [guarded testnet QA guide](https://github.com/fastnear/js-monorepo/blob/main/packages/x402/TESTNET_QA.md) for the shared local-key and browser-wallet release harness.
+
+## Upstream
+
+- [`@x402/near` on npm](https://www.npmjs.com/package/@x402/near)
+- [Merged NEAR mechanism contribution](https://github.com/x402-foundation/x402/pull/2663)
+- [NEAR exact-scheme specification](https://github.com/x402-foundation/x402/blob/2aa22d3e6a38547a8232737599d9f519c9ac5533/specs/schemes/exact/scheme_exact_near.md)

--- a/packages/x402/TESTNET_QA.md
+++ b/packages/x402/TESTNET_QA.md
@@ -46,7 +46,7 @@ yarn smoke:x402:testnet -- \
 
 The harness permits exactly one `send_tx`, checks the serialized inner delegate and outer relayer transaction before forwarding it, waits for `FINAL`, reconciles exact token and nonce deltas, and proves a sequential replay is rejected without another submission. If submission becomes ambiguous, it prints a `near tx-status` reconciliation command and never retries automatically.
 
-## Intear and Meteor gates
+## Browser wallet gate
 
 Omit the payer credential and use `--serve-wallet` with the same confirmations:
 
@@ -66,13 +66,13 @@ yarn smoke:x402:testnet -- \
   --confirm-relayer relayer.mike.testnet \
   --confirm-asset wrap.testnet \
   --confirm-amount 1 \
-  --expected-wallet "Intear Wallet"
+  --expected-wallet "Meteor Wallet"
 ```
 
-Open the printed `127.0.0.1` URL, connect the exact configured account and wallet, and click Pay. The page uses the locally built wallet and x402 IIFEs, fixes the network and payment fields, never auto-connects or auto-pays, and closes its one-shot server after final reconciliation. Run it separately with `--expected-wallet "Intear Wallet"` and `--expected-wallet "Meteor Wallet"`; the exact value must match `nearWallet.walletName()` for the candidate manifest.
+Open the printed `127.0.0.1` URL, connect the exact configured account and wallet, and click Pay. The page uses the locally built wallet and x402 IIFEs, fixes the network and payment fields, never auto-connects or auto-pays, and closes its one-shot server after final reconciliation. Meteor Wallet is the maintained browser-wallet release gate for FastNEAR `1.5.0`; additional wallets should only be documented as compatible after their maintained production executor advertises `signDelegateActionsWithTtl` and passes this same harness. The exact `--expected-wallet` value must match `nearWallet.walletName()` for the active manifest.
 
 The browser session expires after 15 minutes by default. `--wallet-timeout-seconds` accepts 1 through 3600. To test an unpublished near-connect manifest, pass its public HTTPS URL with `--wallet-manifest`; embedded credentials and query strings are rejected because the browser receives the URL.
 
-By default, wallet mode serves the locally built wallet and x402 IIFEs. To run the same gate against published release artifacts, add an exact package version such as `--bundle-version 1.5.0-beta.0`. The page then loads both IIFEs from immutable, exact-version jsDelivr URLs. Tags, ranges, partial versions, and malformed prerelease versions are rejected; `--bundle-version` is only valid with `--serve-wallet`.
+By default, wallet mode serves the locally built wallet and x402 IIFEs. To run the same gate against published release artifacts, add an exact package version such as `--bundle-version 1.5.0`. The page then loads both IIFEs from immutable, exact-version jsDelivr URLs. Tags, ranges, partial versions, and malformed prerelease versions are rejected; `--bundle-version` is only valid with `--serve-wallet`.
 
 Use the installed `near` CLI only for operator setup, balance inspection, and `near tx-status` reconciliation. The payment itself goes through the package's official local signer or wallet bridge and upstream reference relayer.

--- a/packages/x402/TESTNET_QA.md
+++ b/packages/x402/TESTNET_QA.md
@@ -1,0 +1,78 @@
+# `@fastnear/x402` testnet QA
+
+This repository has one guarded harness for the local-key and browser-wallet release gates. It uses the public `@fastnear/x402` factories, an in-process facilitator, a loopback seller, and a transaction-inspecting RPC proxy. Check-only mode is read-only and cannot submit a transaction.
+
+## Read-only preflight
+
+This fixture transfers one atomic unit of `wrap.testnet`. Substitute another testnet NEP-141 token only after funding the payer and registering the recipient for that token's storage.
+
+```bash
+yarn smoke:x402:testnet -- \
+  --check-only \
+  --payer mike.testnet \
+  --payer-credential ~/.near-credentials/testnet/mike.testnet.json \
+  --relayer relayer.mike.testnet \
+  --relayer-credential ~/.near-credentials/testnet/relayer.mike.testnet.json \
+  --pay-to merchant.mike.testnet \
+  --asset wrap.testnet \
+  --amount 1 \
+  --rpc-url https://rpc.testnet.fastnear.com
+```
+
+Credential files must be regular, user-owned files with no group or other permissions (`chmod 600` or `chmod 400`). The preflight verifies the testnet chain ID, final-state full-access keys, token contract, payer balance, recipient storage, relayer balance, facilitator discovery, and the seller's x402 v2 challenge. It prints no secrets, payment headers, or signed delegates.
+
+## One local-key settlement
+
+Run this only after the read-only preflight passes. State-changing mode requires exact confirmations for every actor and payment field.
+
+```bash
+yarn smoke:x402:testnet -- \
+  --execute \
+  --payer mike.testnet \
+  --payer-credential ~/.near-credentials/testnet/mike.testnet.json \
+  --relayer relayer.mike.testnet \
+  --relayer-credential ~/.near-credentials/testnet/relayer.mike.testnet.json \
+  --pay-to merchant.mike.testnet \
+  --asset wrap.testnet \
+  --amount 1 \
+  --rpc-url https://rpc.testnet.fastnear.com \
+  --confirm-network testnet \
+  --confirm-payer mike.testnet \
+  --confirm-pay-to merchant.mike.testnet \
+  --confirm-relayer relayer.mike.testnet \
+  --confirm-asset wrap.testnet \
+  --confirm-amount 1
+```
+
+The harness permits exactly one `send_tx`, checks the serialized inner delegate and outer relayer transaction before forwarding it, waits for `FINAL`, reconciles exact token and nonce deltas, and proves a sequential replay is rejected without another submission. If submission becomes ambiguous, it prints a `near tx-status` reconciliation command and never retries automatically.
+
+## Intear and Meteor gates
+
+Omit the payer credential and use `--serve-wallet` with the same confirmations:
+
+```bash
+yarn smoke:x402:testnet -- \
+  --serve-wallet \
+  --payer mike.testnet \
+  --relayer relayer.mike.testnet \
+  --relayer-credential ~/.near-credentials/testnet/relayer.mike.testnet.json \
+  --pay-to merchant.mike.testnet \
+  --asset wrap.testnet \
+  --amount 1 \
+  --rpc-url https://rpc.testnet.fastnear.com \
+  --confirm-network testnet \
+  --confirm-payer mike.testnet \
+  --confirm-pay-to merchant.mike.testnet \
+  --confirm-relayer relayer.mike.testnet \
+  --confirm-asset wrap.testnet \
+  --confirm-amount 1 \
+  --expected-wallet "Intear Wallet"
+```
+
+Open the printed `127.0.0.1` URL, connect the exact configured account and wallet, and click Pay. The page uses the locally built wallet and x402 IIFEs, fixes the network and payment fields, never auto-connects or auto-pays, and closes its one-shot server after final reconciliation. Run it separately with `--expected-wallet "Intear Wallet"` and `--expected-wallet "Meteor Wallet"`; the exact value must match `nearWallet.walletName()` for the candidate manifest.
+
+The browser session expires after 15 minutes by default. `--wallet-timeout-seconds` accepts 1 through 3600. To test an unpublished near-connect manifest, pass its public HTTPS URL with `--wallet-manifest`; embedded credentials and query strings are rejected because the browser receives the URL.
+
+By default, wallet mode serves the locally built wallet and x402 IIFEs. To run the same gate against published release artifacts, add an exact package version such as `--bundle-version 1.5.0-beta.0`. The page then loads both IIFEs from immutable, exact-version jsDelivr URLs. Tags, ranges, partial versions, and malformed prerelease versions are rejected; `--bundle-version` is only valid with `--serve-wallet`.
+
+Use the installed `near` CLI only for operator setup, balance inspection, and `near tx-status` reconciliation. The payment itself goes through the package's official local signer or wallet bridge and upstream reference relayer.

--- a/packages/x402/package.json
+++ b/packages/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/x402",
-  "version": "1.5.0-beta.1",
+  "version": "1.5.0",
   "description": "FastNEAR wallet, fetch, resource-server, and facilitator adapters for x402 payments on NEAR",
   "license": "MIT",
   "type": "module",

--- a/packages/x402/package.json
+++ b/packages/x402/package.json
@@ -61,10 +61,7 @@
     }
   },
   "dependencies": {
-    "@fastnear/borsh": "workspace:*",
-    "@fastnear/borsh-schema": "workspace:*",
     "@near-js/transactions": "*",
-    "@noble/secp256k1": "*",
     "@x402/core": "*",
     "@x402/fetch": "*",
     "@x402/near": "*"

--- a/packages/x402/package.json
+++ b/packages/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/x402",
-  "version": "1.3.0",
+  "version": "1.5.0-beta.0",
   "description": "FastNEAR wallet, fetch, resource-server, and facilitator adapters for x402 payments on NEAR",
   "license": "MIT",
   "type": "module",

--- a/packages/x402/package.json
+++ b/packages/x402/package.json
@@ -1,0 +1,86 @@
+{
+  "name": "@fastnear/x402",
+  "version": "1.3.0",
+  "description": "FastNEAR wallet, fetch, resource-server, and facilitator adapters for x402 payments on NEAR",
+  "license": "MIT",
+  "type": "module",
+  "types": "./dist/esm/index.d.ts",
+  "main": "./dist/cjs/index.cjs",
+  "module": "./dist/esm/index.js",
+  "browser": "./dist/umd/browser.global.js",
+  "sideEffects": false,
+  "engines": {
+    "node": ">=20.19.0"
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "yarn --cwd ../.. vitest run packages/x402/src",
+    "prepack": "yarn build && node ../../scripts/prepare-package-for-publish.mjs prepare",
+    "postpack": "node ../../scripts/prepare-package-for-publish.mjs restore",
+    "release": "node ../../scripts/publish-packed.mjs",
+    "clean": "yarn rimraf dist node_modules",
+    "type-check": "tsc --noEmit"
+  },
+  "author": "FastNear",
+  "homepage": "https://js.fastnear.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fastnear/js-monorepo.git"
+  },
+  "keywords": [
+    "near-protocol",
+    "x402",
+    "payments",
+    "wallet",
+    "fastnear",
+    "web3"
+  ],
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/esm/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.cjs"
+    },
+    "./node": {
+      "types": "./dist/esm/node.d.ts",
+      "import": "./dist/esm/node.js",
+      "require": "./dist/cjs/node.cjs"
+    },
+    "./server": {
+      "types": "./dist/esm/server.d.ts",
+      "import": "./dist/esm/server.js",
+      "require": "./dist/cjs/server.cjs"
+    },
+    "./facilitator": {
+      "types": "./dist/esm/facilitator.d.ts",
+      "import": "./dist/esm/facilitator.js",
+      "require": "./dist/cjs/facilitator.cjs"
+    }
+  },
+  "dependencies": {
+    "@fastnear/borsh": "workspace:*",
+    "@fastnear/borsh-schema": "workspace:*",
+    "@near-js/transactions": "*",
+    "@noble/secp256k1": "*",
+    "@x402/core": "*",
+    "@x402/fetch": "*",
+    "@x402/near": "*"
+  },
+  "peerDependencies": {
+    "@fastnear/wallet": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@fastnear/wallet": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@fastnear/wallet": "workspace:*",
+    "rimraf": "*",
+    "tsup": "^8.3.6",
+    "typescript": "*"
+  }
+}

--- a/packages/x402/package.json
+++ b/packages/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastnear/x402",
-  "version": "1.5.0-beta.0",
+  "version": "1.5.0-beta.1",
   "description": "FastNEAR wallet, fetch, resource-server, and facilitator adapters for x402 payments on NEAR",
   "license": "MIT",
   "type": "module",

--- a/packages/x402/src/core-integration.test.ts
+++ b/packages/x402/src/core-integration.test.ts
@@ -1,0 +1,282 @@
+import { once } from "node:events";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import {
+  decodePaymentSignatureHeader,
+  encodePaymentRequiredHeader,
+  encodePaymentResponseHeader,
+} from "@x402/core/http";
+import {
+  decodeSignedDelegateB64,
+} from "@x402/near";
+import {
+  decodeSignedTransaction,
+  encodeSignedDelegate,
+} from "@near-js/transactions";
+import { describe, expect, it, vi } from "vitest";
+import { createNearFacilitator } from "./facilitator.js";
+import { createNearPaymentFetch } from "./index.js";
+import { createLocalNearSigner } from "./node.js";
+import { createNearResourceServer } from "./server.js";
+
+const ACCOUNT_ID =
+  "03a107bff3ce10be1d70dd18e74bc09967e4d6309ba50d5f1ddc8664125531b8";
+const SECRET_KEY =
+  "ed25519:1GMkH3brNXiNNs1tiFZHu4yZSRrzJwxi5wB9bHFtMikjwpAW9DMZzU2Pqakc5it8X3N5vPmqdN7KF4CCUpmKhq";
+const RELAYER_SECRET_KEY =
+  "ed25519:AADF5hC4G2hkMNESSHciZowNS79kocbrrSQAkSU7fuUnbvpRJFV9zP6G9GV2vLWFJTmuEyoYSXQiuVczdB5fqU4";
+const PUBLIC_KEY = "ed25519:FAe4sisG95oZ42w7buUn5qEE4TAnfTTFPiguZUHmhiF";
+const ZERO_HASH = "11111111111111111111111111111111";
+const TOKEN_CODE_HASH = "DqWvPnmrMHuQaBnMmLbQ7a7d3i4vdenYMWGyUUFcet8Q";
+const TOKEN_ID = "usdc.fakes.testnet";
+const MERCHANT_ID = "merchant.testnet";
+const FINAL_HEIGHT = 1_000;
+const ACCESS_KEY_NONCE = 41;
+
+async function startMockNearRpc() {
+  const requests: any[] = [];
+  const server = createServer(async (request, response) => {
+    let body = "";
+    for await (const chunk of request) body += chunk;
+    const rpc = JSON.parse(body);
+    requests.push(rpc);
+
+    let result: unknown;
+    if (rpc.method === "query" && rpc.params?.request_type === "view_access_key") {
+      result = {
+        block_hash: ZERO_HASH,
+        block_height: FINAL_HEIGHT,
+        nonce: rpc.params.account_id === "relayer.testnet" ? 7 : ACCESS_KEY_NONCE,
+        permission: "FullAccess",
+      };
+    } else if (rpc.method === "query" && rpc.params?.request_type === "view_account") {
+      result = {
+        amount: "1000000000000000000000000",
+        locked: "0",
+        code_hash: rpc.params.account_id === TOKEN_ID ? TOKEN_CODE_HASH : ZERO_HASH,
+        storage_usage: 0,
+        storage_paid_at: 0,
+        block_height: FINAL_HEIGHT,
+        block_hash: ZERO_HASH,
+      };
+    } else if (rpc.method === "query" && rpc.params?.request_type === "call_function") {
+      const value = rpc.params.method_name === "ft_balance_of"
+        ? "1000000"
+        : { total: "1", available: "0" };
+      result = {
+        result: Array.from(Buffer.from(JSON.stringify(value))),
+        logs: [],
+        block_height: FINAL_HEIGHT,
+        block_hash: ZERO_HASH,
+      };
+    } else if (rpc.method === "block") {
+      result = { header: { height: FINAL_HEIGHT, hash: ZERO_HASH } };
+    } else if (rpc.method === "send_tx") {
+      result = {
+        status: { SuccessValue: "" },
+        transaction_outcome: { id: "settled-transaction-hash" },
+        receipts_outcome: [{
+          outcome: {
+            executor_id: TOKEN_ID,
+            status: { SuccessValue: "" },
+          },
+        }],
+      };
+    } else {
+      response.writeHead(400, { "content-type": "application/json" });
+      response.end(JSON.stringify({
+        jsonrpc: "2.0",
+        id: rpc.id,
+        error: { code: -32601, message: `Unexpected RPC method: ${rpc.method}` },
+      }));
+      return;
+    }
+
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify({ jsonrpc: "2.0", id: rpc.id, result }));
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    requests,
+    url: `http://127.0.0.1:${port}`,
+    close: async () => {
+      server.close();
+      await once(server, "close");
+    },
+  };
+}
+
+describe("wallet-free x402 integration", () => {
+  it("signs, verifies, settles, and retries through the public factories", async () => {
+    const rpc = await startMockNearRpc();
+    try {
+      const facilitator = createNearFacilitator({
+        registrations: [{
+          network: "near:testnet",
+          signer: {
+            relayers: [{
+              accountId: "relayer.testnet",
+              secretKey: RELAYER_SECRET_KEY,
+            }],
+            rpcUrls: { "near:testnet": rpc.url },
+          },
+        }],
+      });
+      const resourceServer = createNearResourceServer({
+        facilitators: facilitator,
+      });
+      await resourceServer.initialize();
+
+      const [requirements] = await resourceServer.buildPaymentRequirementsFromOptions([{
+        scheme: "exact",
+        network: "near:testnet",
+        payTo: MERCHANT_ID,
+        price: { asset: TOKEN_ID, amount: "10" },
+        maxTimeoutSeconds: 300,
+      }], {});
+      const paymentRequired = await resourceServer.createPaymentRequiredResponse(
+        [requirements],
+        {
+          url: "https://seller.example.test/paid",
+          description: "Wallet-free integration fixture",
+          mimeType: "application/json",
+        },
+      );
+
+      let capturedPayment: ReturnType<typeof decodePaymentSignatureHeader> | undefined;
+      const sellerFetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        if (sellerFetch.mock.calls.length === 1) {
+          return new Response(null, {
+            status: 402,
+            headers: {
+              "PAYMENT-REQUIRED": encodePaymentRequiredHeader(paymentRequired),
+            },
+          });
+        }
+
+        const request = input instanceof Request ? input : new Request(input, init);
+        const paymentHeader = request.headers.get("PAYMENT-SIGNATURE");
+        expect(paymentHeader).toBeTruthy();
+        capturedPayment = decodePaymentSignatureHeader(paymentHeader!);
+        const matched = resourceServer.findMatchingRequirements(
+          paymentRequired.accepts,
+          capturedPayment,
+        );
+        expect(matched).toEqual(requirements);
+
+        const verification = await resourceServer.verifyPayment(capturedPayment, matched!);
+        expect(verification).toMatchObject({ isValid: true, payer: ACCOUNT_ID });
+        const settlement = await resourceServer.settlePayment(capturedPayment, matched!);
+        expect(settlement).toMatchObject({
+          success: true,
+          transaction: "settled-transaction-hash",
+          network: "near:testnet",
+          payer: ACCOUNT_ID,
+        });
+        return new Response(JSON.stringify({ paid: true }), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "PAYMENT-RESPONSE": encodePaymentResponseHeader(settlement),
+          },
+        });
+      });
+
+      const signer = createLocalNearSigner({
+        accountId: ACCOUNT_ID,
+        secretKey: SECRET_KEY,
+        rpcUrls: { "near:testnet": rpc.url },
+      });
+      const paidFetch = createNearPaymentFetch({
+        signer,
+        fetch: sellerFetch,
+        network: "near:testnet",
+      });
+      const response = await paidFetch("https://seller.example.test/paid");
+
+      await expect(response.json()).resolves.toEqual({ paid: true });
+      expect(sellerFetch).toHaveBeenCalledTimes(2);
+      expect(rpc.requests).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          method: "query",
+          params: expect.objectContaining({
+            request_type: "view_access_key",
+            account_id: ACCOUNT_ID,
+            public_key: PUBLIC_KEY,
+            finality: "final",
+          }),
+        }),
+        expect.objectContaining({
+          method: "block",
+          params: { finality: "final" },
+        }),
+      ]));
+
+      const submission = rpc.requests.find(request => request.method === "send_tx");
+      expect(submission).toMatchObject({
+        method: "send_tx",
+        params: {
+          wait_until: "FINAL",
+          signed_tx_base64: expect.any(String),
+        },
+      });
+      const outerTransaction = decodeSignedTransaction(
+        Buffer.from(submission.params.signed_tx_base64, "base64"),
+      );
+      expect(outerTransaction.transaction).toMatchObject({
+        signerId: "relayer.testnet",
+        receiverId: ACCOUNT_ID,
+        nonce: 8n,
+      });
+      expect(outerTransaction.transaction.actions).toHaveLength(1);
+      const submittedDelegate = outerTransaction.transaction.actions[0].signedDelegate;
+      expect(submittedDelegate).toBeDefined();
+      expect(Buffer.from(encodeSignedDelegate(submittedDelegate!)).toString("base64")).toBe(
+        capturedPayment!.payload.signedDelegateAction,
+      );
+
+      const decoded = decodeSignedDelegateB64(
+        capturedPayment!.payload.signedDelegateAction as string,
+      );
+      expect(decoded.verifySignature()).toBe(true);
+      expect(decoded.delegate).toMatchObject({
+        senderId: ACCOUNT_ID,
+        receiverId: TOKEN_ID,
+        nonce: 42n,
+        maxBlockHeight: 1_300n,
+        actionCount: 1,
+      });
+      expect(decoded.delegate.functionCall).toMatchObject({
+        methodName: "ft_transfer",
+        gas: 30_000_000_000_000n,
+        deposit: 1n,
+      });
+
+      const restrictiveFacilitator = createNearFacilitator({
+        registrations: [{
+          network: "near:testnet",
+          signer: {
+            relayers: [{
+              accountId: "relayer.testnet",
+              secretKey: RELAYER_SECRET_KEY,
+            }],
+            rpcUrls: { "near:testnet": rpc.url },
+          },
+          maxSponsoredGas: 29_999_999_999_999n,
+        }],
+      });
+      await expect(
+        restrictiveFacilitator.verify(capturedPayment!, requirements),
+      ).resolves.toMatchObject({
+        isValid: false,
+        invalidReason: "invalid_exact_near_payload_gas_limit_exceeded",
+        payer: ACCOUNT_ID,
+      });
+    } finally {
+      await rpc.close();
+    }
+  });
+});

--- a/packages/x402/src/facilitator.test.ts
+++ b/packages/x402/src/facilitator.test.ts
@@ -1,0 +1,99 @@
+import {
+  SettlementCache,
+  type FacilitatorNearSigner,
+} from "@x402/near";
+import { describe, expect, it } from "vitest";
+import { createNearFacilitator } from "./facilitator.js";
+
+const signer = {
+  getRelayerIds: () => ["relayer.testnet"],
+  getCurrentBlockHeight: async () => 1n,
+  viewAccount: async () => null,
+  viewAccessKey: async () => null,
+  ftBalanceOf: async () => 0n,
+  storageBalanceOf: async () => ({ supported: false as const }),
+  submitSignedDelegateAction: async () => ({
+    transaction: "test",
+    innerReceipt: { kind: "success" as const, value: "" },
+  }),
+} as unknown as FacilitatorNearSigner;
+
+function registeredScheme(facilitator: unknown): any {
+  return (facilitator as any).registeredFacilitatorSchemes.get(2)[0].facilitator;
+}
+
+describe("createNearFacilitator", () => {
+  it("registers multiple concrete NEAR networks", () => {
+    const facilitator = createNearFacilitator({
+      registrations: [
+        { network: "near:mainnet", signer },
+        { network: "near:testnet", signer, maxSponsoredGas: 30_000_000_000_000n },
+      ],
+    });
+    expect(facilitator.getSupported().kinds).toEqual(expect.arrayContaining([
+      expect.objectContaining({ network: "near:mainnet", scheme: "exact", x402Version: 2 }),
+      expect.objectContaining({ network: "near:testnet", scheme: "exact", x402Version: 2 }),
+    ]));
+  });
+
+  it("forwards settlement cache and gas options to a custom signer", () => {
+    const settlementCache = new SettlementCache();
+    const facilitator = createNearFacilitator({
+      registrations: [{
+        network: "near:testnet",
+        signer,
+        settlementCache,
+        maxSponsoredGas: 12_345n,
+      }],
+    });
+    const scheme = registeredScheme(facilitator);
+    expect(scheme.signer).toBe(signer);
+    expect(scheme.settlementCache).toBe(settlementCache);
+    expect(scheme.maxSponsoredGas).toBe(12_345n);
+  });
+
+  it("creates the upstream reference signer from relayer configuration", () => {
+    const facilitator = createNearFacilitator({
+      registrations: [{
+        network: "near:testnet",
+        signer: {
+          relayers: [{
+            accountId: "relayer.testnet",
+            secretKey: "ed25519:9TQiNdoKW9ecwDFx7HF5fovv3aLz7HdMJQ32iCXSraJ2eKx2mcLuDNqrproewz8hBHR3wBkZLDQ9hesRAoDuYkm",
+          }],
+          rpcUrls: {
+            "near:testnet": "https://rpc.testnet.example",
+          },
+        },
+      }],
+    });
+    expect(registeredScheme(facilitator).signer.getRelayerIds()).toEqual([
+      "relayer.testnet",
+    ]);
+  });
+
+  it("rejects empty, duplicate, and invalid registrations", () => {
+    expect(() => createNearFacilitator({ registrations: [] })).toThrow("At least one");
+    expect(() => createNearFacilitator({ registrations: [
+      { network: "near:testnet", signer },
+      { network: "near:testnet", signer },
+    ] })).toThrow("Duplicate");
+    expect(() => createNearFacilitator({ registrations: [
+      { network: "near:testnet", signer, maxSponsoredGas: 0n },
+    ] })).toThrow("positive bigint");
+    for (const invalid of [Number.NaN, Number.POSITIVE_INFINITY, "30000000000000"]) {
+      expect(() => createNearFacilitator({ registrations: [{
+        network: "near:testnet",
+        signer,
+        maxSponsoredGas: invalid as never,
+      }] })).toThrow("positive bigint");
+    }
+  });
+
+  it("rejects reference signer configuration without relayers", () => {
+    expect(() => createNearFacilitator({ registrations: [{
+      network: "near:testnet",
+      signer: { relayers: [] },
+    }] })).toThrow("At least one relayer");
+  });
+});

--- a/packages/x402/src/facilitator.ts
+++ b/packages/x402/src/facilitator.ts
@@ -1,0 +1,110 @@
+import { x402Facilitator } from "@x402/core/facilitator";
+import {
+  createFacilitatorNearSigner,
+  type FacilitatorNearSigner,
+  type FacilitatorNearSignerConfig,
+  type SettlementCache,
+} from "@x402/near";
+import { ExactNearScheme } from "@x402/near/exact/facilitator";
+import type { NearNetwork } from "./index.js";
+
+export interface NearFacilitatorRegistration {
+  network: NearNetwork;
+  signer: FacilitatorNearSigner | FacilitatorNearSignerConfig;
+  settlementCache?: SettlementCache;
+  maxSponsoredGas?: bigint;
+}
+
+export interface NearFacilitatorOptions {
+  registrations: readonly NearFacilitatorRegistration[];
+}
+
+function isFacilitatorNearSigner(value: unknown): value is FacilitatorNearSigner {
+  const requiredMethods = [
+    "getRelayerIds",
+    "getCurrentBlockHeight",
+    "viewAccount",
+    "viewAccessKey",
+    "ftBalanceOf",
+    "storageBalanceOf",
+    "submitSignedDelegateAction",
+  ] as const;
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    requiredMethods.every(
+      method => typeof (value as unknown as Record<string, unknown>)[method] === "function",
+    ),
+  );
+}
+
+/** Create a self-hostable core facilitator registered for concrete NEAR networks. */
+export function createNearFacilitator({
+  registrations,
+}: NearFacilitatorOptions): x402Facilitator {
+  if (!Array.isArray(registrations) || registrations.length === 0) {
+    throw new Error("At least one NEAR facilitator registration is required");
+  }
+
+  const facilitator = new x402Facilitator();
+  const networks = new Set<NearNetwork>();
+
+  for (const registration of registrations) {
+    if (!registration || typeof registration !== "object") {
+      throw new Error("Each NEAR facilitator registration must be an object");
+    }
+    if (registration.network !== "near:mainnet" && registration.network !== "near:testnet") {
+      throw new Error(`Unsupported NEAR facilitator network: ${registration.network}`);
+    }
+    if (networks.has(registration.network)) {
+      throw new Error(`Duplicate NEAR facilitator network: ${registration.network}`);
+    }
+    networks.add(registration.network);
+
+    if (
+      registration.maxSponsoredGas !== undefined &&
+      (typeof registration.maxSponsoredGas !== "bigint" || registration.maxSponsoredGas <= 0n)
+    ) {
+      throw new Error("maxSponsoredGas must be a positive bigint");
+    }
+
+    let signer: FacilitatorNearSigner;
+    if (isFacilitatorNearSigner(registration.signer)) {
+      signer = registration.signer;
+    } else {
+      if (
+        !registration.signer ||
+        typeof registration.signer !== "object" ||
+        !Array.isArray(registration.signer.relayers) ||
+        registration.signer.relayers.length === 0
+      ) {
+        throw new Error(`At least one relayer is required for ${registration.network}`);
+      }
+      signer = createFacilitatorNearSigner(registration.signer);
+    }
+
+    const relayerIds = signer.getRelayerIds();
+    if (
+      !Array.isArray(relayerIds) ||
+      relayerIds.length === 0 ||
+      relayerIds.some(relayerId => typeof relayerId !== "string" || relayerId.trim().length === 0)
+    ) {
+      throw new Error(`At least one valid relayer is required for ${registration.network}`);
+    }
+
+    facilitator.register(
+      registration.network,
+      new ExactNearScheme(signer, registration.settlementCache, {
+        maxSponsoredGas: registration.maxSponsoredGas,
+      }),
+    );
+  }
+
+  return facilitator;
+}
+
+export type {
+  FacilitatorNearSigner,
+  FacilitatorNearSignerConfig,
+  SettlementCache,
+} from "@x402/near";

--- a/packages/x402/src/index.test.ts
+++ b/packages/x402/src/index.test.ts
@@ -1,0 +1,344 @@
+import { encodePaymentRequiredHeader } from "@x402/core/http";
+import type { PaymentRequirements } from "@x402/core/types";
+import { encodeSignedDelegate } from "@near-js/transactions";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createFastNearWalletSigner,
+  createNearPaymentFetch,
+  createNearX402Client,
+  type FastNearWalletModule,
+} from "./index.js";
+
+type WalletModuleCompatibility = typeof import("@fastnear/wallet") extends FastNearWalletModule
+  ? true
+  : never;
+const walletModuleCompatibility: WalletModuleCompatibility = true;
+
+const requirements: PaymentRequirements = {
+  scheme: "exact",
+  network: "near:testnet",
+  asset: "usdc.fakes.testnet",
+  amount: "12345",
+  payTo: "merchant.testnet",
+  maxTimeoutSeconds: 300,
+  extra: {},
+};
+
+const signedDelegate = {
+  delegateAction: {
+    senderId: "payer.testnet",
+    receiverId: "usdc.fakes.testnet",
+    actions: [{
+      functionCall: {
+        methodName: "ft_transfer",
+        args: Array.from(new TextEncoder().encode('{"receiver_id":"merchant.testnet","amount":"12345"}')),
+        gas: 30_000_000_000_000n,
+        deposit: 1n,
+      },
+    }],
+    nonce: 1n,
+    maxBlockHeight: 301n,
+    publicKey: {
+      ed25519Key: {
+        data: Array.from(Buffer.from("6kpsY+KcUgq+9VB7Ey7F+ZVHdq6+vnuSQh7qaRRG0iw=", "base64")),
+      },
+    },
+  },
+  signature: {
+    ed25519Signature: {
+      data: Array.from(Buffer.from(
+        "nt2IJzTY/xGqyVWtFaDvKd85kM+eiGSiL9JfV4D2g+nHpxFwE/3DhaMcjd7CjtX2vgKfPE0yjhUaW2ZY+Ou1AA==",
+        "base64",
+      )),
+    },
+  },
+};
+
+const encodedSignedDelegate = Buffer.from(
+  encodeSignedDelegate(signedDelegate as never),
+).toString("base64");
+
+const secp256k1SignedDelegate = {
+  ...signedDelegate,
+  delegateAction: {
+    ...signedDelegate.delegateAction,
+    publicKey: {
+      secp256k1Key: {
+        data: Array.from(Buffer.from(
+          "VrMoswyL9YOeJAWHR4eUCL2zYkHcnC58YZ+qErKSCWerfNn/jqf9T0IbHhn1LpVdSXosgyhaao/3LFd9bC/UkA==",
+          "base64",
+        )),
+      },
+    },
+  },
+  signature: {
+    secp256k1Signature: {
+      data: Array.from(Buffer.from(
+        "skNYqVxh/JoaIxCIjDLuZ/JohTh3ee+FYHbIJQJ9o4tGdARjEVWk4B07IXp3KrPBmaltu+3CJv/nJc4vYxeZaQA=",
+        "base64",
+      )),
+    },
+  },
+};
+
+const encodedSecp256k1SignedDelegate = Buffer.from(
+  encodeSignedDelegate(secp256k1SignedDelegate as never),
+).toString("base64");
+
+const encodedInvalidSignatureDelegate = Buffer.from(
+  encodeSignedDelegate({
+    ...signedDelegate,
+    signature: { ed25519Signature: { data: new Array(64).fill(0) } },
+  } as never),
+).toString("base64");
+
+function walletReturning(result: unknown, account = "payer.testnet") {
+  return {
+    accountId: vi.fn(() => account),
+    signDelegateActions: vi.fn(async (_params: unknown) => ({ signedDelegateActions: [result] })),
+  };
+}
+
+describe("createFastNearWalletSigner", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("builds the exact NEP-141 transfer and forwards the timeout", async () => {
+    const wallet = walletReturning({ borshSerializedBase64: encodedSignedDelegate });
+    const signer = createFastNearWalletSigner({ wallet: wallet as never });
+
+    await expect(signer.createSignedDelegateAction({
+      x402Version: 2,
+      paymentRequirements: requirements,
+    })).resolves.toBe(encodedSignedDelegate);
+
+    expect(wallet.accountId).toHaveBeenCalledWith({ network: "testnet" });
+    expect(wallet.signDelegateActions).toHaveBeenCalledWith({
+      network: "testnet",
+      signerId: "payer.testnet",
+      delegateActions: [{
+        receiverId: "usdc.fakes.testnet",
+        blockHeightTtl: 300,
+        actions: [{
+          type: "FunctionCall",
+          params: {
+            methodName: "ft_transfer",
+            args: { receiver_id: "merchant.testnet", amount: "12345" },
+            gas: "30000000000000",
+            deposit: "1",
+          },
+        }],
+      }],
+    });
+  });
+
+  it("maps mainnet and rounds fractional timeout seconds up", async () => {
+    const wallet = walletReturning(encodedSignedDelegate);
+    const signer = createFastNearWalletSigner({ wallet: wallet as never });
+    await signer.createSignedDelegateAction({
+      x402Version: 2,
+      paymentRequirements: {
+        ...requirements,
+        network: "near:mainnet",
+        maxTimeoutSeconds: 1.01,
+      },
+    });
+    expect(wallet.accountId).toHaveBeenCalledWith({ network: "mainnet" });
+    expect(wallet.signDelegateActions).toHaveBeenCalledWith(expect.objectContaining({
+      delegateActions: [expect.objectContaining({ blockHeightTtl: 2 })],
+    }));
+  });
+
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+    "rejects invalid timeout %s",
+    async maxTimeoutSeconds => {
+      const signer = createFastNearWalletSigner({
+        wallet: walletReturning(encodedSignedDelegate) as never,
+      });
+      await expect(signer.createSignedDelegateAction({
+        x402Version: 2,
+        paymentRequirements: { ...requirements, maxTimeoutSeconds },
+      })).rejects.toThrow("positive finite number");
+    },
+  );
+
+  it("normalizes legacy SignedDelegate objects", async () => {
+    const wallet = walletReturning({ signedDelegate });
+    const signer = createFastNearWalletSigner({ wallet: wallet as never });
+    await expect(signer.createSignedDelegateAction({
+      x402Version: 2,
+      paymentRequirements: requirements,
+    })).resolves.toBe(encodedSignedDelegate);
+  });
+
+  it("accepts a valid secp256k1 wallet signature", async () => {
+    const signer = createFastNearWalletSigner({
+      wallet: walletReturning(encodedSecp256k1SignedDelegate) as never,
+    });
+    await expect(signer.createSignedDelegateAction({
+      x402Version: 2,
+      paymentRequirements: requirements,
+    })).resolves.toBe(encodedSecp256k1SignedDelegate);
+  });
+
+  it.each([
+    ["unsupported version", 1, requirements, "Unsupported x402 version"],
+    ["unsupported scheme", 2, { ...requirements, scheme: "upto" }, "Unsupported x402 NEAR scheme"],
+    ["unsupported network", 2, { ...requirements, network: "eip155:1" }, "Unsupported x402 NEAR network"],
+  ])("rejects %s", async (_label, version, paymentRequirements, message) => {
+    const signer = createFastNearWalletSigner({ wallet: walletReturning(encodedSignedDelegate) as never });
+    await expect(signer.createSignedDelegateAction({
+      x402Version: version as number,
+      paymentRequirements: paymentRequirements as PaymentRequirements,
+    })).rejects.toThrow(message);
+  });
+
+  it("rejects disconnected and non-compliant wallets", async () => {
+    const disconnected = walletReturning(encodedSignedDelegate, "");
+    const disconnectedSigner = createFastNearWalletSigner({ wallet: disconnected as never });
+    await expect(disconnectedSigner.createSignedDelegateAction({
+      x402Version: 2,
+      paymentRequirements: requirements,
+    })).rejects.toThrow("No FastNEAR wallet is connected");
+
+    const unsupported = walletReturning(encodedSignedDelegate);
+    unsupported.signDelegateActions.mockRejectedValueOnce(new Error("does not support timeout-aware delegate signing"));
+    const unsupportedSigner = createFastNearWalletSigner({ wallet: unsupported as never });
+    await expect(unsupportedSigner.createSignedDelegateAction({
+      x402Version: 2,
+      paymentRequirements: requirements,
+    })).rejects.toThrow("timeout-aware delegate signing");
+  });
+
+  it("rejects invalid wallet responses", async () => {
+    const wrongPayment = {
+      ...signedDelegate,
+      delegateAction: {
+        ...signedDelegate.delegateAction,
+        receiverId: "evil-token.testnet",
+      },
+    };
+    const wrongPaymentDelegate = Buffer.from(
+      encodeSignedDelegate(wrongPayment as never),
+    ).toString("base64");
+    const delegateWithTrailingData = Buffer.concat([
+      Buffer.from(encodedSignedDelegate, "base64"),
+      Buffer.from([0]),
+    ]).toString("base64");
+
+    for (const response of [
+      [],
+      [encodedSignedDelegate, encodedSignedDelegate],
+      ["not base64!"],
+      [wrongPaymentDelegate],
+      [delegateWithTrailingData],
+    ]) {
+      const wallet = {
+        accountId: () => "payer.testnet",
+        signDelegateActions: async () => ({ signedDelegateActions: response }),
+      };
+      const signer = createFastNearWalletSigner({ wallet: wallet as never });
+      await expect(signer.createSignedDelegateAction({
+        x402Version: 2,
+        paymentRequirements: requirements,
+      })).rejects.toThrow();
+    }
+  });
+
+  it("rejects an exact delegate with an invalid signature before retry", async () => {
+    const signer = createFastNearWalletSigner({
+      wallet: walletReturning(encodedInvalidSignatureDelegate) as never,
+    });
+
+    await expect(signer.createSignedDelegateAction({
+      x402Version: 2,
+      paymentRequirements: requirements,
+    })).rejects.toThrow("signature");
+  });
+
+  it("does not expose a valid delegate for different payment details", async () => {
+    const stolenDelegate = {
+      ...signedDelegate,
+      delegateAction: {
+        ...signedDelegate.delegateAction,
+        receiverId: "evil-token.testnet",
+        actions: [{
+          functionCall: {
+            ...signedDelegate.delegateAction.actions[0].functionCall,
+            args: Array.from(new TextEncoder().encode(
+              '{"receiver_id":"attacker.testnet","amount":"999999999"}',
+            )),
+          },
+        }],
+      },
+    };
+    const encoded = Buffer.from(
+      encodeSignedDelegate(stolenDelegate as never),
+    ).toString("base64");
+    const signer = createFastNearWalletSigner({
+      wallet: walletReturning(encoded) as never,
+    });
+
+    await expect(signer.createSignedDelegateAction({
+      x402Version: 2,
+      paymentRequirements: requirements,
+    })).rejects.toThrow("does not match the payment request");
+  });
+});
+
+describe("x402 client and fetch helpers", () => {
+  it("creates a client registered for NEAR exact", async () => {
+    const createSignedDelegateAction = vi.fn(async () => encodedSignedDelegate);
+    const client = createNearX402Client({ signer: { createSignedDelegateAction } });
+    const payment = await client.createPaymentPayload({
+      x402Version: 2,
+      resource: { url: "https://example.test/paid" },
+      accepts: [requirements],
+    });
+    expect(payment.payload).toEqual({ signedDelegateAction: encodedSignedDelegate });
+    expect(createSignedDelegateAction).toHaveBeenCalledWith({
+      x402Version: 2,
+      paymentRequirements: requirements,
+    });
+  });
+
+  it("retries a 402 response with a payment signature", async () => {
+    const paymentRequired = encodePaymentRequiredHeader({
+      x402Version: 2,
+      resource: { url: "https://example.test/paid" },
+      accepts: [requirements],
+    });
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(null, {
+        status: 402,
+        headers: { "PAYMENT-REQUIRED": paymentRequired },
+      }))
+      .mockResolvedValueOnce(new Response("paid", { status: 200 }));
+    const signer = { createSignedDelegateAction: vi.fn(async () => encodedSignedDelegate) };
+    const paidFetch = createNearPaymentFetch({ signer, fetch: fetchMock });
+
+    const response = await paidFetch("https://example.test/paid");
+    expect(await response.text()).toBe("paid");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const retriedRequest = fetchMock.mock.calls[1][0] as Request;
+    expect(retriedRequest.headers.get("PAYMENT-SIGNATURE")).toBeTruthy();
+  });
+
+  it("does not retry the HTTP request after an invalid wallet signature", async () => {
+    const paymentRequired = encodePaymentRequiredHeader({
+      x402Version: 2,
+      resource: { url: "https://example.test/paid" },
+      accepts: [requirements],
+    });
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, {
+      status: 402,
+      headers: { "PAYMENT-REQUIRED": paymentRequired },
+    }));
+    const signer = createFastNearWalletSigner({
+      wallet: walletReturning(encodedInvalidSignatureDelegate) as never,
+    });
+    const paidFetch = createNearPaymentFetch({ signer, fetch: fetchMock });
+
+    await expect(paidFetch("https://example.test/paid")).rejects.toThrow("signature");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/x402/src/index.test.ts
+++ b/packages/x402/src/index.test.ts
@@ -58,40 +58,6 @@ const encodedSignedDelegate = Buffer.from(
   encodeSignedDelegate(signedDelegate as never),
 ).toString("base64");
 
-const secp256k1SignedDelegate = {
-  ...signedDelegate,
-  delegateAction: {
-    ...signedDelegate.delegateAction,
-    publicKey: {
-      secp256k1Key: {
-        data: Array.from(Buffer.from(
-          "VrMoswyL9YOeJAWHR4eUCL2zYkHcnC58YZ+qErKSCWerfNn/jqf9T0IbHhn1LpVdSXosgyhaao/3LFd9bC/UkA==",
-          "base64",
-        )),
-      },
-    },
-  },
-  signature: {
-    secp256k1Signature: {
-      data: Array.from(Buffer.from(
-        "skNYqVxh/JoaIxCIjDLuZ/JohTh3ee+FYHbIJQJ9o4tGdARjEVWk4B07IXp3KrPBmaltu+3CJv/nJc4vYxeZaQA=",
-        "base64",
-      )),
-    },
-  },
-};
-
-const encodedSecp256k1SignedDelegate = Buffer.from(
-  encodeSignedDelegate(secp256k1SignedDelegate as never),
-).toString("base64");
-
-const encodedInvalidSignatureDelegate = Buffer.from(
-  encodeSignedDelegate({
-    ...signedDelegate,
-    signature: { ed25519Signature: { data: new Array(64).fill(0) } },
-  } as never),
-).toString("base64");
-
 function walletReturning(result: unknown, account = "payer.testnet") {
   return {
     accountId: vi.fn(() => account),
@@ -161,6 +127,19 @@ describe("createFastNearWalletSigner", () => {
     },
   );
 
+  it("rejects a timeout that cannot be forwarded as a safe wallet TTL", async () => {
+    const signer = createFastNearWalletSigner({
+      wallet: walletReturning(encodedSignedDelegate) as never,
+    });
+    await expect(signer.createSignedDelegateAction({
+      x402Version: 2,
+      paymentRequirements: {
+        ...requirements,
+        maxTimeoutSeconds: Number.MAX_SAFE_INTEGER + 1,
+      },
+    })).rejects.toThrow("delegate-action limit");
+  });
+
   it("normalizes legacy SignedDelegate objects", async () => {
     const wallet = walletReturning({ signedDelegate });
     const signer = createFastNearWalletSigner({ wallet: wallet as never });
@@ -168,16 +147,6 @@ describe("createFastNearWalletSigner", () => {
       x402Version: 2,
       paymentRequirements: requirements,
     })).resolves.toBe(encodedSignedDelegate);
-  });
-
-  it("accepts a valid secp256k1 wallet signature", async () => {
-    const signer = createFastNearWalletSigner({
-      wallet: walletReturning(encodedSecp256k1SignedDelegate) as never,
-    });
-    await expect(signer.createSignedDelegateAction({
-      x402Version: 2,
-      paymentRequirements: requirements,
-    })).resolves.toBe(encodedSecp256k1SignedDelegate);
   });
 
   it.each([
@@ -209,79 +178,25 @@ describe("createFastNearWalletSigner", () => {
     })).rejects.toThrow("timeout-aware delegate signing");
   });
 
-  it("rejects invalid wallet responses", async () => {
-    const wrongPayment = {
-      ...signedDelegate,
-      delegateAction: {
-        ...signedDelegate.delegateAction,
-        receiverId: "evil-token.testnet",
-      },
+  it.each([
+    ["zero results", []],
+    ["multiple results", [encodedSignedDelegate, encodedSignedDelegate]],
+    ["malformed base64", ["not base64!"]],
+    ["noncanonical base64", ["YQ"]],
+    ["empty base64", [""]],
+    ["invalid canonical result", [{ borshSerializedBase64: 123 }]],
+    ["invalid legacy result", [{ signedDelegate: null }]],
+    ["unsupported result", [{}]],
+  ])("rejects %s", async (_label, response) => {
+    const wallet = {
+      accountId: () => "payer.testnet",
+      signDelegateActions: async () => ({ signedDelegateActions: response }),
     };
-    const wrongPaymentDelegate = Buffer.from(
-      encodeSignedDelegate(wrongPayment as never),
-    ).toString("base64");
-    const delegateWithTrailingData = Buffer.concat([
-      Buffer.from(encodedSignedDelegate, "base64"),
-      Buffer.from([0]),
-    ]).toString("base64");
-
-    for (const response of [
-      [],
-      [encodedSignedDelegate, encodedSignedDelegate],
-      ["not base64!"],
-      [wrongPaymentDelegate],
-      [delegateWithTrailingData],
-    ]) {
-      const wallet = {
-        accountId: () => "payer.testnet",
-        signDelegateActions: async () => ({ signedDelegateActions: response }),
-      };
-      const signer = createFastNearWalletSigner({ wallet: wallet as never });
-      await expect(signer.createSignedDelegateAction({
-        x402Version: 2,
-        paymentRequirements: requirements,
-      })).rejects.toThrow();
-    }
-  });
-
-  it("rejects an exact delegate with an invalid signature before retry", async () => {
-    const signer = createFastNearWalletSigner({
-      wallet: walletReturning(encodedInvalidSignatureDelegate) as never,
-    });
-
+    const signer = createFastNearWalletSigner({ wallet: wallet as never });
     await expect(signer.createSignedDelegateAction({
       x402Version: 2,
       paymentRequirements: requirements,
-    })).rejects.toThrow("signature");
-  });
-
-  it("does not expose a valid delegate for different payment details", async () => {
-    const stolenDelegate = {
-      ...signedDelegate,
-      delegateAction: {
-        ...signedDelegate.delegateAction,
-        receiverId: "evil-token.testnet",
-        actions: [{
-          functionCall: {
-            ...signedDelegate.delegateAction.actions[0].functionCall,
-            args: Array.from(new TextEncoder().encode(
-              '{"receiver_id":"attacker.testnet","amount":"999999999"}',
-            )),
-          },
-        }],
-      },
-    };
-    const encoded = Buffer.from(
-      encodeSignedDelegate(stolenDelegate as never),
-    ).toString("base64");
-    const signer = createFastNearWalletSigner({
-      wallet: walletReturning(encoded) as never,
-    });
-
-    await expect(signer.createSignedDelegateAction({
-      x402Version: 2,
-      paymentRequirements: requirements,
-    })).rejects.toThrow("does not match the payment request");
+    })).rejects.toThrow();
   });
 });
 
@@ -323,7 +238,7 @@ describe("x402 client and fetch helpers", () => {
     expect(retriedRequest.headers.get("PAYMENT-SIGNATURE")).toBeTruthy();
   });
 
-  it("does not retry the HTTP request after an invalid wallet signature", async () => {
+  it("does not retry the HTTP request after a malformed wallet response", async () => {
     const paymentRequired = encodePaymentRequiredHeader({
       x402Version: 2,
       resource: { url: "https://example.test/paid" },
@@ -334,11 +249,11 @@ describe("x402 client and fetch helpers", () => {
       headers: { "PAYMENT-REQUIRED": paymentRequired },
     }));
     const signer = createFastNearWalletSigner({
-      wallet: walletReturning(encodedInvalidSignatureDelegate) as never,
+      wallet: walletReturning("not base64!") as never,
     });
     const paidFetch = createNearPaymentFetch({ signer, fetch: fetchMock });
 
-    await expect(paidFetch("https://example.test/paid")).rejects.toThrow("signature");
+    await expect(paidFetch("https://example.test/paid")).rejects.toThrow("malformed");
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/x402/src/index.ts
+++ b/packages/x402/src/index.ts
@@ -1,0 +1,361 @@
+import type { x402Client as X402Client } from "@x402/core/client";
+import { x402Client } from "@x402/core/client";
+import { wrapFetchWithPayment } from "@x402/fetch";
+import { deserialize, serialize } from "@fastnear/borsh";
+import { nearChainSchema } from "@fastnear/borsh-schema";
+import {
+  encodeDelegateAction,
+  encodeSignedDelegate,
+  type SignedDelegate,
+} from "@near-js/transactions";
+import { verify as verifySecp256k1 } from "@noble/secp256k1";
+import type { ClientNearSigner } from "@x402/near";
+import { ExactNearScheme } from "@x402/near/exact/client";
+
+export type NearNetwork = "near:mainnet" | "near:testnet";
+export type NearNetworkPattern = NearNetwork | "near:*";
+
+export interface FastNearWalletModule {
+  accountId(options?: { network?: "mainnet" | "testnet" }): string | null;
+  signDelegateActions(params: {
+    network?: "mainnet" | "testnet";
+    signerId?: string;
+    delegateActions: Array<{
+      receiverId: string;
+      blockHeightTtl?: number;
+      actions: Array<{
+        type: "FunctionCall";
+        params: {
+          methodName: string;
+          args: Record<string, string>;
+          gas: string;
+          deposit: string;
+        };
+      }>;
+    }>;
+  }): Promise<{ signedDelegateActions: unknown[] }>;
+}
+
+export interface FastNearWalletSignerOptions {
+  wallet: FastNearWalletModule;
+}
+
+export interface NearX402ClientOptions {
+  signer: ClientNearSigner;
+  network?: NearNetworkPattern;
+}
+
+export interface NearPaymentFetchOptions extends NearX402ClientOptions {
+  fetch?: typeof globalThis.fetch;
+}
+
+const NEAR_NETWORKS = new Set<NearNetwork>(["near:mainnet", "near:testnet"]);
+const FT_TRANSFER_GAS = "30000000000000";
+const ONE_YOCTO = "1";
+
+function toWalletNetwork(network: string): "mainnet" | "testnet" {
+  if (!NEAR_NETWORKS.has(network as NearNetwork)) {
+    throw new Error(`Unsupported x402 NEAR network: ${network}`);
+  }
+  return network === "near:mainnet" ? "mainnet" : "testnet";
+}
+
+function timeoutBlocks(maxTimeoutSeconds: number): number {
+  if (!Number.isFinite(maxTimeoutSeconds) || maxTimeoutSeconds <= 0) {
+    throw new Error("x402 maxTimeoutSeconds must be a positive finite number");
+  }
+  const blocks = Math.ceil(maxTimeoutSeconds);
+  if (!Number.isSafeInteger(blocks)) {
+    throw new Error("x402 timeout exceeds the wallet delegate-action limit");
+  }
+  return blocks;
+}
+
+function toBase64(bytes: Uint8Array): string {
+  if (typeof Buffer !== "undefined") return Buffer.from(bytes).toString("base64");
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+function fromBase64(value: string): Uint8Array {
+  if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)) {
+    throw new Error("Wallet returned a malformed signed delegate action");
+  }
+  try {
+    if (typeof Buffer !== "undefined") return new Uint8Array(Buffer.from(value, "base64"));
+    const binary = atob(value);
+    return Uint8Array.from(binary, character => character.charCodeAt(0));
+  } catch {
+    throw new Error("Wallet returned a malformed signed delegate action");
+  }
+}
+
+interface DecodedFunctionCall {
+  methodName: string;
+  args: number[];
+  gas: bigint;
+  deposit: bigint;
+}
+
+interface RawKeyOrSignature {
+  data: number[];
+}
+
+interface DecodedSignedDelegate {
+  delegateAction: {
+    senderId: string;
+    receiverId: string;
+    actions: Array<{ functionCall?: DecodedFunctionCall }>;
+    nonce: bigint;
+    maxBlockHeight: bigint;
+    publicKey: {
+      ed25519Key?: RawKeyOrSignature;
+      secp256k1Key?: RawKeyOrSignature;
+    };
+  };
+  signature: {
+    ed25519Signature?: RawKeyOrSignature;
+    secp256k1Signature?: RawKeyOrSignature;
+  };
+}
+
+interface SignedDelegateExpectation {
+  signerId: string;
+  asset: string;
+  payTo: string;
+  amount: string;
+}
+
+function decodeSignedDelegate(value: string): DecodedSignedDelegate {
+  try {
+    const bytes = fromBase64(value);
+    if (bytes.length === 0 || toBase64(bytes) !== value) throw new Error("non-canonical base64");
+    const decoded = deserialize(
+      nearChainSchema.SignedDelegate,
+      bytes,
+    ) as DecodedSignedDelegate;
+    const canonical = serialize(nearChainSchema.SignedDelegate, decoded);
+    if (
+      canonical.length !== bytes.length ||
+      canonical.some((byte, index) => byte !== bytes[index])
+    ) {
+      throw new Error("non-canonical signed delegate");
+    }
+    return decoded;
+  } catch {
+    throw new Error("Wallet returned a malformed signed delegate action");
+  }
+}
+
+function invalidDelegate(reason: string): never {
+  throw new Error(`Wallet returned a signed delegate that does not match the payment request: ${reason}`);
+}
+
+async function hasValidSignature(signedDelegate: DecodedSignedDelegate): Promise<boolean> {
+  const { delegateAction, signature } = signedDelegate;
+  const subtle = globalThis.crypto?.subtle;
+  if (!subtle) return false;
+  const digest = new Uint8Array(
+    await subtle.digest("SHA-256", encodeDelegateAction(delegateAction as never)),
+  );
+  const edKey = delegateAction.publicKey.ed25519Key;
+  const edSignature = signature.ed25519Signature;
+  if (edKey && edSignature) {
+    try {
+      const publicKey = await subtle.importKey(
+        "raw",
+        Uint8Array.from(edKey.data),
+        "Ed25519",
+        false,
+        ["verify"],
+      );
+      return await subtle.verify(
+        "Ed25519",
+        publicKey,
+        Uint8Array.from(edSignature.data),
+        digest,
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  const secpKey = delegateAction.publicKey.secp256k1Key;
+  const secpSignature = signature.secp256k1Signature;
+  if (secpKey && secpSignature) {
+    const publicKey = new Uint8Array(65);
+    publicKey[0] = 4;
+    publicKey.set(secpKey.data, 1);
+    return verifySecp256k1(
+      Uint8Array.from(secpSignature.data).subarray(0, 64),
+      digest,
+      publicKey,
+      { prehash: false, lowS: false },
+    );
+  }
+  return false;
+}
+
+async function assertDelegateMatches(
+  signedDelegate: DecodedSignedDelegate,
+  expected: SignedDelegateExpectation,
+): Promise<void> {
+  const delegate = signedDelegate.delegateAction;
+  if (!delegate || delegate.senderId !== expected.signerId) invalidDelegate("signer");
+  if (delegate.receiverId !== expected.asset) invalidDelegate("token contract");
+  if (!Array.isArray(delegate.actions) || delegate.actions.length !== 1) {
+    invalidDelegate("action count");
+  }
+
+  const action = delegate.actions[0];
+  const functionCall = action?.functionCall;
+  if (!functionCall || Object.keys(action).length !== 1) invalidDelegate("action kind");
+  if (functionCall.methodName !== "ft_transfer") invalidDelegate("method name");
+  if (functionCall.gas !== BigInt(FT_TRANSFER_GAS)) invalidDelegate("gas");
+  if (functionCall.deposit !== BigInt(ONE_YOCTO)) invalidDelegate("deposit");
+
+  let args: unknown;
+  try {
+    const json = new TextDecoder("utf-8", { fatal: true }).decode(
+      Uint8Array.from(functionCall.args),
+    );
+    args = JSON.parse(json);
+  } catch {
+    invalidDelegate("ft_transfer arguments");
+  }
+  if (!args || typeof args !== "object" || Array.isArray(args)) {
+    invalidDelegate("ft_transfer arguments");
+  }
+  const transfer = args as Record<string, unknown>;
+  if (
+    Object.keys(transfer).length !== 2 ||
+    transfer.receiver_id !== expected.payTo ||
+    transfer.amount !== expected.amount
+  ) {
+    invalidDelegate("ft_transfer arguments");
+  }
+  if (typeof delegate.nonce !== "bigint" || delegate.nonce <= 0n) invalidDelegate("nonce");
+  if (typeof delegate.maxBlockHeight !== "bigint" || delegate.maxBlockHeight <= 0n) {
+    invalidDelegate("maximum block height");
+  }
+  if (!await hasValidSignature(signedDelegate)) invalidDelegate("signature");
+}
+
+async function normalizeSignedDelegate(
+  result: unknown,
+  expected: SignedDelegateExpectation,
+): Promise<string> {
+  let encoded: string;
+  if (typeof result === "string") {
+    encoded = result;
+  } else if (result && typeof result === "object" && "borshSerializedBase64" in result) {
+    const value = (result as { borshSerializedBase64?: unknown }).borshSerializedBase64;
+    if (typeof value !== "string") {
+      throw new Error("Wallet returned an invalid borshSerializedBase64 value");
+    }
+    encoded = value;
+  } else if (result && typeof result === "object" && "signedDelegate" in result) {
+    const signedDelegate = (result as { signedDelegate?: SignedDelegate }).signedDelegate;
+    if (!signedDelegate || typeof signedDelegate !== "object") {
+      throw new Error("Wallet returned an invalid signedDelegate value");
+    }
+    try {
+      encoded = toBase64(encodeSignedDelegate(signedDelegate));
+    } catch {
+      throw new Error("Wallet returned an invalid signedDelegate value");
+    }
+  } else {
+    throw new Error("Wallet returned an unsupported signed delegate result");
+  }
+  if (encoded.length === 0) throw new Error("Wallet returned an empty signed delegate action");
+  await assertDelegateMatches(decodeSignedDelegate(encoded), expected);
+  return encoded;
+}
+
+/** Adapt @fastnear/wallet to the signer interface expected by x402 NEAR exact. */
+export function createFastNearWalletSigner({
+  wallet,
+}: FastNearWalletSignerOptions): ClientNearSigner {
+  if (!wallet || typeof wallet.accountId !== "function" || typeof wallet.signDelegateActions !== "function") {
+    throw new Error("A FastNEAR wallet module with accountId and signDelegateActions is required");
+  }
+
+  return {
+    async createSignedDelegateAction({ x402Version, paymentRequirements }) {
+      if (x402Version !== 2) {
+        throw new Error(`Unsupported x402 version for NEAR payments: ${x402Version}`);
+      }
+      if (paymentRequirements.scheme !== "exact") {
+        throw new Error(`Unsupported x402 NEAR scheme: ${paymentRequirements.scheme}`);
+      }
+      const network = toWalletNetwork(paymentRequirements.network);
+      const signerId = wallet.accountId({ network });
+      if (!signerId) throw new Error(`No FastNEAR wallet is connected on ${network}`);
+
+      const response = await wallet.signDelegateActions({
+        network,
+        signerId,
+        delegateActions: [{
+          receiverId: paymentRequirements.asset,
+          blockHeightTtl: timeoutBlocks(paymentRequirements.maxTimeoutSeconds),
+          actions: [{
+            type: "FunctionCall",
+            params: {
+              methodName: "ft_transfer",
+              args: {
+                receiver_id: paymentRequirements.payTo,
+                amount: paymentRequirements.amount,
+              },
+              gas: FT_TRANSFER_GAS,
+              deposit: ONE_YOCTO,
+            },
+          }],
+        }],
+      });
+
+      const results = response?.signedDelegateActions;
+      if (!Array.isArray(results) || results.length !== 1) {
+        throw new Error(`Wallet must return exactly one signed delegate action; received ${results?.length ?? 0}`);
+      }
+      return normalizeSignedDelegate(results[0], {
+        signerId,
+        asset: paymentRequirements.asset,
+        payTo: paymentRequirements.payTo,
+        amount: paymentRequirements.amount,
+      });
+    },
+  };
+}
+
+/** Create an x402 client registered only for the official NEAR exact scheme. */
+export function createNearX402Client({
+  signer,
+  network = "near:*",
+}: NearX402ClientOptions): X402Client {
+  if (!signer || typeof signer.createSignedDelegateAction !== "function") {
+    throw new Error("A NEAR x402 client signer is required");
+  }
+  if (network !== "near:*" && !NEAR_NETWORKS.has(network)) {
+    throw new Error(`Unsupported x402 NEAR network pattern: ${network}`);
+  }
+  return new x402Client().register(network, new ExactNearScheme(signer));
+}
+
+/** Create a fetch-compatible function that handles x402 payment challenges. */
+export function createNearPaymentFetch({
+  signer,
+  fetch: fetchImplementation = globalThis.fetch,
+  network = "near:*",
+}: NearPaymentFetchOptions): typeof globalThis.fetch {
+  if (typeof fetchImplementation !== "function") {
+    throw new Error("A fetch implementation is required");
+  }
+  return wrapFetchWithPayment(
+    fetchImplementation,
+    createNearX402Client({ signer, network }),
+  );
+}
+
+export type { ClientNearSigner } from "@x402/near";
+export type { x402Client } from "@x402/core/client";

--- a/packages/x402/src/index.ts
+++ b/packages/x402/src/index.ts
@@ -1,14 +1,10 @@
 import type { x402Client as X402Client } from "@x402/core/client";
 import { x402Client } from "@x402/core/client";
 import { wrapFetchWithPayment } from "@x402/fetch";
-import { deserialize, serialize } from "@fastnear/borsh";
-import { nearChainSchema } from "@fastnear/borsh-schema";
 import {
-  encodeDelegateAction,
   encodeSignedDelegate,
   type SignedDelegate,
 } from "@near-js/transactions";
-import { verify as verifySecp256k1 } from "@noble/secp256k1";
 import type { ClientNearSigner } from "@x402/near";
 import { ExactNearScheme } from "@x402/near/exact/client";
 
@@ -52,6 +48,8 @@ export interface NearPaymentFetchOptions extends NearX402ClientOptions {
 const NEAR_NETWORKS = new Set<NearNetwork>(["near:mainnet", "near:testnet"]);
 const FT_TRANSFER_GAS = "30000000000000";
 const ONE_YOCTO = "1";
+// The official NEAR exact v2 scheme estimates one block per second.
+const ESTIMATED_BLOCK_SECONDS = 1;
 
 function toWalletNetwork(network: string): "mainnet" | "testnet" {
   if (!NEAR_NETWORKS.has(network as NearNetwork)) {
@@ -64,7 +62,7 @@ function timeoutBlocks(maxTimeoutSeconds: number): number {
   if (!Number.isFinite(maxTimeoutSeconds) || maxTimeoutSeconds <= 0) {
     throw new Error("x402 maxTimeoutSeconds must be a positive finite number");
   }
-  const blocks = Math.ceil(maxTimeoutSeconds);
+  const blocks = Math.ceil(maxTimeoutSeconds / ESTIMATED_BLOCK_SECONDS);
   if (!Number.isSafeInteger(blocks)) {
     throw new Error("x402 timeout exceeds the wallet delegate-action limit");
   }
@@ -91,161 +89,19 @@ function fromBase64(value: string): Uint8Array {
   }
 }
 
-interface DecodedFunctionCall {
-  methodName: string;
-  args: number[];
-  gas: bigint;
-  deposit: bigint;
-}
-
-interface RawKeyOrSignature {
-  data: number[];
-}
-
-interface DecodedSignedDelegate {
-  delegateAction: {
-    senderId: string;
-    receiverId: string;
-    actions: Array<{ functionCall?: DecodedFunctionCall }>;
-    nonce: bigint;
-    maxBlockHeight: bigint;
-    publicKey: {
-      ed25519Key?: RawKeyOrSignature;
-      secp256k1Key?: RawKeyOrSignature;
-    };
-  };
-  signature: {
-    ed25519Signature?: RawKeyOrSignature;
-    secp256k1Signature?: RawKeyOrSignature;
-  };
-}
-
-interface SignedDelegateExpectation {
-  signerId: string;
-  asset: string;
-  payTo: string;
-  amount: string;
-}
-
-function decodeSignedDelegate(value: string): DecodedSignedDelegate {
+function assertCanonicalBase64(value: string): void {
   try {
     const bytes = fromBase64(value);
     if (bytes.length === 0 || toBase64(bytes) !== value) throw new Error("non-canonical base64");
-    const decoded = deserialize(
-      nearChainSchema.SignedDelegate,
-      bytes,
-    ) as DecodedSignedDelegate;
-    const canonical = serialize(nearChainSchema.SignedDelegate, decoded);
-    if (
-      canonical.length !== bytes.length ||
-      canonical.some((byte, index) => byte !== bytes[index])
-    ) {
-      throw new Error("non-canonical signed delegate");
-    }
-    return decoded;
   } catch {
     throw new Error("Wallet returned a malformed signed delegate action");
   }
 }
 
-function invalidDelegate(reason: string): never {
-  throw new Error(`Wallet returned a signed delegate that does not match the payment request: ${reason}`);
-}
-
-async function hasValidSignature(signedDelegate: DecodedSignedDelegate): Promise<boolean> {
-  const { delegateAction, signature } = signedDelegate;
-  const subtle = globalThis.crypto?.subtle;
-  if (!subtle) return false;
-  const digest = new Uint8Array(
-    await subtle.digest("SHA-256", encodeDelegateAction(delegateAction as never)),
-  );
-  const edKey = delegateAction.publicKey.ed25519Key;
-  const edSignature = signature.ed25519Signature;
-  if (edKey && edSignature) {
-    try {
-      const publicKey = await subtle.importKey(
-        "raw",
-        Uint8Array.from(edKey.data),
-        "Ed25519",
-        false,
-        ["verify"],
-      );
-      return await subtle.verify(
-        "Ed25519",
-        publicKey,
-        Uint8Array.from(edSignature.data),
-        digest,
-      );
-    } catch {
-      return false;
-    }
-  }
-
-  const secpKey = delegateAction.publicKey.secp256k1Key;
-  const secpSignature = signature.secp256k1Signature;
-  if (secpKey && secpSignature) {
-    const publicKey = new Uint8Array(65);
-    publicKey[0] = 4;
-    publicKey.set(secpKey.data, 1);
-    return verifySecp256k1(
-      Uint8Array.from(secpSignature.data).subarray(0, 64),
-      digest,
-      publicKey,
-      { prehash: false, lowS: false },
-    );
-  }
-  return false;
-}
-
-async function assertDelegateMatches(
-  signedDelegate: DecodedSignedDelegate,
-  expected: SignedDelegateExpectation,
-): Promise<void> {
-  const delegate = signedDelegate.delegateAction;
-  if (!delegate || delegate.senderId !== expected.signerId) invalidDelegate("signer");
-  if (delegate.receiverId !== expected.asset) invalidDelegate("token contract");
-  if (!Array.isArray(delegate.actions) || delegate.actions.length !== 1) {
-    invalidDelegate("action count");
-  }
-
-  const action = delegate.actions[0];
-  const functionCall = action?.functionCall;
-  if (!functionCall || Object.keys(action).length !== 1) invalidDelegate("action kind");
-  if (functionCall.methodName !== "ft_transfer") invalidDelegate("method name");
-  if (functionCall.gas !== BigInt(FT_TRANSFER_GAS)) invalidDelegate("gas");
-  if (functionCall.deposit !== BigInt(ONE_YOCTO)) invalidDelegate("deposit");
-
-  let args: unknown;
-  try {
-    const json = new TextDecoder("utf-8", { fatal: true }).decode(
-      Uint8Array.from(functionCall.args),
-    );
-    args = JSON.parse(json);
-  } catch {
-    invalidDelegate("ft_transfer arguments");
-  }
-  if (!args || typeof args !== "object" || Array.isArray(args)) {
-    invalidDelegate("ft_transfer arguments");
-  }
-  const transfer = args as Record<string, unknown>;
-  if (
-    Object.keys(transfer).length !== 2 ||
-    transfer.receiver_id !== expected.payTo ||
-    transfer.amount !== expected.amount
-  ) {
-    invalidDelegate("ft_transfer arguments");
-  }
-  if (typeof delegate.nonce !== "bigint" || delegate.nonce <= 0n) invalidDelegate("nonce");
-  if (typeof delegate.maxBlockHeight !== "bigint" || delegate.maxBlockHeight <= 0n) {
-    invalidDelegate("maximum block height");
-  }
-  if (!await hasValidSignature(signedDelegate)) invalidDelegate("signature");
-}
-
-async function normalizeSignedDelegate(
-  result: unknown,
-  expected: SignedDelegateExpectation,
-): Promise<string> {
+// Compliant wallet transports validate the delegate they sign, and @x402/near's
+// facilitator is the authoritative payload/signature verifier. This adapter
+// intentionally validates only the response envelope, not the protocol again.
+function normalizeSignedDelegate(result: unknown): string {
   let encoded: string;
   if (typeof result === "string") {
     encoded = result;
@@ -268,8 +124,7 @@ async function normalizeSignedDelegate(
   } else {
     throw new Error("Wallet returned an unsupported signed delegate result");
   }
-  if (encoded.length === 0) throw new Error("Wallet returned an empty signed delegate action");
-  await assertDelegateMatches(decodeSignedDelegate(encoded), expected);
+  assertCanonicalBase64(encoded);
   return encoded;
 }
 
@@ -318,12 +173,7 @@ export function createFastNearWalletSigner({
       if (!Array.isArray(results) || results.length !== 1) {
         throw new Error(`Wallet must return exactly one signed delegate action; received ${results?.length ?? 0}`);
       }
-      return normalizeSignedDelegate(results[0], {
-        signerId,
-        asset: paymentRequirements.asset,
-        payTo: paymentRequirements.payTo,
-        amount: paymentRequirements.amount,
-      });
+      return normalizeSignedDelegate(results[0]);
     },
   };
 }

--- a/packages/x402/src/node.ts
+++ b/packages/x402/src/node.ts
@@ -1,0 +1,4 @@
+export {
+  createClientNearSigner as createLocalNearSigner,
+  type ClientNearSignerConfig,
+} from "@x402/near";

--- a/packages/x402/src/server.test.ts
+++ b/packages/x402/src/server.test.ts
@@ -1,0 +1,119 @@
+import type { FacilitatorClient } from "@x402/core/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createNearResourceServer } from "./server.js";
+
+function facilitatorClient(): FacilitatorClient {
+  return {
+    verify: vi.fn(),
+    settle: vi.fn(),
+    getSupported: vi.fn(async () => ({
+      kinds: [{ x402Version: 2, scheme: "exact", network: "near:testnet" }],
+      extensions: [],
+      signers: {},
+    })),
+  } as unknown as FacilitatorClient;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("createNearResourceServer", () => {
+  it("registers the official exact scheme for NEAR", () => {
+    const server = createNearResourceServer({ facilitators: facilitatorClient() });
+    expect(server.hasRegisteredScheme("near:mainnet", "exact")).toBe(true);
+    expect(server.hasRegisteredScheme("near:testnet", "exact")).toBe(true);
+  });
+
+  it("accepts explicit HTTP endpoints and registers money parsers", async () => {
+    const createAuthHeaders = vi.fn(async () => ({
+      verify: { authorization: "test" },
+      settle: { authorization: "test" },
+      supported: { authorization: "test" },
+    }));
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      const body = url.endsWith("/verify")
+        ? { isValid: true, payer: "payer.testnet" }
+        : url.endsWith("/settle")
+          ? {
+              success: true,
+              transaction: "remote-settlement",
+              network: "near:testnet",
+              payer: "payer.testnet",
+            }
+          : {
+              kinds: [{ x402Version: 2, scheme: "exact", network: "near:testnet" }],
+              extensions: [],
+              signers: {},
+            };
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const httpServer = createNearResourceServer({
+      facilitators: [{
+        url: "https://facilitator.example.test",
+        createAuthHeaders,
+      }],
+    });
+    await httpServer.initialize();
+    expect(createAuthHeaders).toHaveBeenCalledWith();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://facilitator.example.test/supported",
+      expect.objectContaining({
+        headers: expect.objectContaining({ authorization: "test" }),
+      }),
+    );
+
+    const [remoteRequirements] = await httpServer.buildPaymentRequirementsFromOptions([{
+      scheme: "exact",
+      network: "near:testnet",
+      payTo: "merchant.testnet",
+      price: { asset: "usdc.fakes.testnet", amount: "42" },
+    }], {});
+    const remotePayload = {
+      x402Version: 2,
+      accepted: remoteRequirements,
+      payload: { signedDelegateAction: "test-fixture" },
+    };
+    await expect(
+      httpServer.verifyPayment(remotePayload, remoteRequirements),
+    ).resolves.toMatchObject({ isValid: true, payer: "payer.testnet" });
+    await expect(
+      httpServer.settlePayment(remotePayload, remoteRequirements),
+    ).resolves.toMatchObject({ success: true, transaction: "remote-settlement" });
+    for (const path of ["verify", "settle"]) {
+      expect(fetchMock).toHaveBeenCalledWith(
+        `https://facilitator.example.test/${path}`,
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({ authorization: "test" }),
+        }),
+      );
+    }
+
+    const parser = vi.fn(async () => ({ asset: "custom-token.testnet", amount: "42" }));
+    const server = createNearResourceServer({
+      facilitators: facilitatorClient(),
+      moneyParsers: [parser],
+    });
+    await server.initialize();
+
+    const built = await server.buildPaymentRequirementsFromOptions([{
+      scheme: "exact",
+      network: "near:testnet",
+      payTo: "merchant.testnet",
+      price: "$1.00",
+    }], {});
+    expect(parser).toHaveBeenCalledWith(1, "near:testnet");
+    expect(built[0]).toMatchObject({ asset: "custom-token.testnet", amount: "42" });
+  });
+
+  it("never allows an implicit facilitator", () => {
+    expect(() => createNearResourceServer({ facilitators: [] })).toThrow("At least one");
+    expect(() => createNearResourceServer({ facilitators: { url: "" } })).toThrow("non-empty URL");
+  });
+});

--- a/packages/x402/src/server.ts
+++ b/packages/x402/src/server.ts
@@ -1,0 +1,83 @@
+import {
+  HTTPFacilitatorClient,
+  x402ResourceServer,
+  type FacilitatorClient,
+  type FacilitatorConfig,
+} from "@x402/core/server";
+import type { x402Facilitator } from "@x402/core/facilitator";
+import type { MoneyParser } from "@x402/core/types";
+import { ExactNearScheme } from "@x402/near/exact/server";
+
+export type NearMoneyParser = MoneyParser;
+
+export type FacilitatorEndpointConfig = Omit<FacilitatorConfig, "url"> & {
+  url: string;
+};
+
+/** Core facilitator shape accepted for same-process verification/settlement. */
+export type InProcessFacilitator = Pick<
+  x402Facilitator,
+  "verify" | "settle" | "getSupported"
+>;
+
+export type NearFacilitatorClient = FacilitatorClient | InProcessFacilitator;
+
+export interface NearResourceServerOptions {
+  facilitators:
+    | NearFacilitatorClient
+    | FacilitatorEndpointConfig
+    | readonly (NearFacilitatorClient | FacilitatorEndpointConfig)[];
+  moneyParsers?: readonly NearMoneyParser[];
+}
+
+function isInProcessFacilitator(value: unknown): value is NearFacilitatorClient {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    typeof (value as FacilitatorClient).verify === "function" &&
+    typeof (value as FacilitatorClient).settle === "function" &&
+    typeof (value as FacilitatorClient).getSupported === "function",
+  );
+}
+
+function endpointToClient(
+  endpoint: NearFacilitatorClient | FacilitatorEndpointConfig,
+): FacilitatorClient {
+  if (isInProcessFacilitator(endpoint)) {
+    return {
+      verify: (payload, requirements) => endpoint.verify(payload, requirements),
+      settle: (payload, requirements) => endpoint.settle(payload, requirements),
+      getSupported: async () => (
+        await endpoint.getSupported()
+      ) as Awaited<ReturnType<FacilitatorClient["getSupported"]>>,
+    };
+  }
+  if (!endpoint || typeof endpoint.url !== "string" || endpoint.url.trim().length === 0) {
+    throw new Error("Each x402 facilitator endpoint requires a non-empty URL");
+  }
+  return new HTTPFacilitatorClient(endpoint);
+}
+
+/**
+ * Create a resource server with the official NEAR server scheme and an
+ * explicitly configured facilitator. No default facilitator is used.
+ */
+export function createNearResourceServer({
+  facilitators,
+  moneyParsers = [],
+}: NearResourceServerOptions): x402ResourceServer {
+  const configured = Array.isArray(facilitators) ? [...facilitators] : [facilitators];
+  if (configured.length === 0) {
+    throw new Error("At least one NEAR-capable x402 facilitator is required");
+  }
+
+  const clients = configured.map(endpointToClient);
+  const scheme = new ExactNearScheme();
+  for (const parser of moneyParsers) {
+    scheme.registerMoneyParser(parser);
+  }
+
+  return new x402ResourceServer(clients).register("near:*", scheme);
+}
+
+export type { FacilitatorClient } from "@x402/core/server";

--- a/packages/x402/tsconfig.json
+++ b/packages/x402/tsconfig.json
@@ -9,8 +9,6 @@
     "resolveJsonModule": true,
     "types": ["node"],
     "paths": {
-      "@fastnear/borsh": ["../borsh/src/index.ts"],
-      "@fastnear/borsh-schema": ["../borsh-schema/src/index.ts"],
       "@fastnear/wallet": ["../wallet/src/index.ts"]
     }
   },

--- a/packages/x402/tsconfig.json
+++ b/packages/x402/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist/esm",
+    "declaration": true,
+    "declarationMap": true,
+    "resolveJsonModule": true,
+    "types": ["node"],
+    "paths": {
+      "@fastnear/borsh": ["../borsh/src/index.ts"],
+      "@fastnear/borsh-schema": ["../borsh-schema/src/index.ts"],
+      "@fastnear/wallet": ["../wallet/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*", "../../types/*.d.ts"]
+}

--- a/packages/x402/tsup.config.ts
+++ b/packages/x402/tsup.config.ts
@@ -1,0 +1,14 @@
+import pkg from "./package.json";
+import { createFastNearTsupConfig } from "../../scripts/tsup-config";
+
+export default createFastNearTsupConfig({
+  manifest: pkg,
+  bannerName: "x402",
+  globalName: "nearX402",
+  moduleEntries: {
+    index: "src/index.ts",
+    node: "src/node.ts",
+    server: "src/server.ts",
+    facilitator: "src/facilitator.ts",
+  },
+});

--- a/recipes/index.json
+++ b/recipes/index.json
@@ -1962,7 +1962,7 @@
       "paymentAsset": "NEP-141 fungible tokens"
     },
     "browserGlobal": "nearX402",
-    "browserStatus": "Preview: requires a compatible upcoming near-connect release and a wallet that advertises timeout-aware delegate signing; the currently published wallet bridge is not production-compatible.",
+    "browserStatus": "Beta: requires @fastnear/near-connect 0.13+ and a wallet that advertises both timeout-aware delegate-signing capabilities; production wallet manifest activation remains QA-gated.",
     "walletFeatures": [
       "signDelegateActions",
       "signDelegateActionsWithTtl"
@@ -1990,7 +1990,7 @@
           "@fastnear/wallet",
           "@fastnear/x402"
         ],
-        "status": "preview until the timeout-aware wallet bridge ships"
+        "status": "beta until Intear and Meteor production wallet QA pass"
       },
       {
         "task": "Protect a seller resource",

--- a/recipes/index.json
+++ b/recipes/index.json
@@ -1,5 +1,5 @@
 {
-  "version": 4,
+  "version": 5,
   "homepage": "https://js.fastnear.com",
   "source": "recipes/source.mjs",
   "catalogUrl": "https://js.fastnear.com/recipes.json",
@@ -7,7 +7,8 @@
     "@fastnear/api",
     "@fastnear/wallet",
     "@fastnear/utils",
-    "@fastnear/ml-dsa-65"
+    "@fastnear/ml-dsa-65",
+    "@fastnear/x402"
   ],
   "support": {
     "apiKeyEnvVar": "FASTNEAR_API_KEY",
@@ -1942,6 +1943,144 @@
         "summary": "Query the full key directly, then match its locally derived hash handle against the compact list response.",
         "language": "js",
         "code": "import {\n  queryAccessKey,\n  queryAccessKeyList,\n} from \"@fastnear/api\";\nimport { publicKeyToHandle } from \"@fastnear/ml-dsa-65\";\n\nexport async function findMlDsa65AccessKey({ accountId, publicKey }) {\n  const [direct, list] = await Promise.all([\n    queryAccessKey({ accountId, publicKey, network: \"testnet\" }),\n    queryAccessKeyList({ accountId, network: \"testnet\" }),\n  ]);\n  const publicKeyHandle = publicKeyToHandle(publicKey);\n  const listed = list.result.keys.find(\n    (entry) => entry.public_key === publicKeyHandle,\n  );\n\n  return { direct: direct.result, publicKeyHandle, listed };\n}"
+      }
+    ]
+  },
+  "x402": {
+    "package": "@fastnear/x402",
+    "runtime": "Package-only; not included in agents.js or near.js.",
+    "guideUrl": "https://github.com/fastnear/js-monorepo/blob/main/packages/x402/README.md",
+    "protocol": {
+      "version": 2,
+      "scheme": "exact",
+      "networks": [
+        "near:mainnet",
+        "near:testnet"
+      ],
+      "authorization": "NEP-366 SignedDelegate",
+      "paymentAsset": "NEP-141 fungible tokens"
+    },
+    "browserGlobal": "nearX402",
+    "browserStatus": "Preview: requires a compatible upcoming near-connect release and a wallet that advertises timeout-aware delegate signing; the currently published wallet bridge is not production-compatible.",
+    "walletFeatures": [
+      "signDelegateActions",
+      "signDelegateActionsWithTtl"
+    ],
+    "chooseByTask": [
+      {
+        "task": "Pay an x402 URL from Node.js",
+        "use": [
+          "createLocalNearSigner",
+          "createNearPaymentFetch"
+        ],
+        "imports": [
+          "@fastnear/x402/node",
+          "@fastnear/x402"
+        ],
+        "status": "stable core path"
+      },
+      {
+        "task": "Pay an x402 URL from a browser wallet",
+        "use": [
+          "createFastNearWalletSigner",
+          "createNearPaymentFetch"
+        ],
+        "imports": [
+          "@fastnear/wallet",
+          "@fastnear/x402"
+        ],
+        "status": "preview until the timeout-aware wallet bridge ships"
+      },
+      {
+        "task": "Protect a seller resource",
+        "use": [
+          "createNearResourceServer"
+        ],
+        "imports": [
+          "@fastnear/x402/server"
+        ],
+        "status": "requires an explicit facilitator"
+      },
+      {
+        "task": "Operate a NEAR facilitator",
+        "use": [
+          "createNearFacilitator"
+        ],
+        "imports": [
+          "@fastnear/x402/facilitator"
+        ],
+        "status": "HTTP framework and secret storage are operator choices"
+      },
+      {
+        "task": "Integrate below the paid-fetch helper",
+        "use": [
+          "createNearX402Client"
+        ],
+        "imports": [
+          "@fastnear/x402"
+        ],
+        "status": "lower-level client path"
+      }
+    ],
+    "entrypoints": [
+      {
+        "subpath": "@fastnear/x402",
+        "exports": [
+          "createFastNearWalletSigner",
+          "createNearX402Client",
+          "createNearPaymentFetch"
+        ],
+        "purpose": "injected FastNEAR wallet signer, NEAR-only x402 client, and paid fetch"
+      },
+      {
+        "subpath": "@fastnear/x402/node",
+        "exports": [
+          "createLocalNearSigner"
+        ],
+        "purpose": "official RPC-backed local full-access-key signer"
+      },
+      {
+        "subpath": "@fastnear/x402/server",
+        "exports": [
+          "createNearResourceServer"
+        ],
+        "purpose": "resource server with one or more explicitly configured facilitators"
+      },
+      {
+        "subpath": "@fastnear/x402/facilitator",
+        "exports": [
+          "createNearFacilitator"
+        ],
+        "purpose": "self-hosted facilitator registration for concrete NEAR networks"
+      }
+    ],
+    "constraints": [
+      "Only x402 v2 exact payments on near:mainnet and near:testnet are supported.",
+      "Payments use NEP-141 tokens; native NEAR is not a direct payment asset.",
+      "Wallet and local-key payers require full-access keys, and recipients need token storage registration.",
+      "Resource servers require an explicit facilitator; no x402.org or other default is selected.",
+      "Browser wallet access is injected explicitly and payment occurs only when the application calls the paid fetch function."
+    ],
+    "safeDefaults": [
+      "Pin near:testnet during development and a concrete NEAR network in production; use near:* only for an intentionally cross-network client.",
+      "Keep payer and relayer secret keys in server-side secret storage, never browser code.",
+      "String and number seller prices use the official USDC contract; wNEAR and custom tokens require an explicit { amount, asset } price.",
+      "Always configure a facilitator explicitly."
+    ],
+    "quickstarts": [
+      {
+        "id": "x402-node-paid-fetch",
+        "title": "Pay an x402 URL from Node.js",
+        "summary": "Use the upstream local full-access-key signer with the high-level paid-fetch helper.",
+        "language": "js",
+        "code": "import { createNearPaymentFetch } from \"@fastnear/x402\";\nimport { createLocalNearSigner } from \"@fastnear/x402/node\";\n\nconst { NEAR_PAYER_ACCOUNT_ID, NEAR_PAYER_SECRET_KEY, X402_RESOURCE_URL } = process.env;\nif (!NEAR_PAYER_ACCOUNT_ID || !NEAR_PAYER_SECRET_KEY || !X402_RESOURCE_URL) {\n  throw new Error(\"NEAR_PAYER_ACCOUNT_ID, NEAR_PAYER_SECRET_KEY, and X402_RESOURCE_URL are required\");\n}\n\nconst signer = createLocalNearSigner({\n  accountId: NEAR_PAYER_ACCOUNT_ID,\n  secretKey: NEAR_PAYER_SECRET_KEY,\n  rpcUrls: { \"near:testnet\": \"https://rpc.testnet.fastnear.com\" },\n});\nconst paidFetch = createNearPaymentFetch({ signer, network: \"near:testnet\" });\nconst response = await paidFetch(X402_RESOURCE_URL);\nif (!response.ok) throw new Error(`Paid request failed: ${response.status}`);\nconsole.log(await response.json());"
+      },
+      {
+        "id": "x402-remote-facilitator-seller",
+        "title": "Configure a seller with an explicit remote facilitator",
+        "summary": "Create the NEAR resource-server core, then pass it to the x402 HTTP framework adapter you choose.",
+        "language": "js",
+        "code": "import { createNearResourceServer } from \"@fastnear/x402/server\";\n\nconst { X402_FACILITATOR_URL } = process.env;\nif (!X402_FACILITATOR_URL) throw new Error(\"X402_FACILITATOR_URL is required\");\n\nexport const resourceServer = createNearResourceServer({\n  facilitators: { url: X402_FACILITATOR_URL },\n});\nawait resourceServer.initialize();"
       }
     ]
   },

--- a/recipes/index.json
+++ b/recipes/index.json
@@ -1962,7 +1962,7 @@
       "paymentAsset": "NEP-141 fungible tokens"
     },
     "browserGlobal": "nearX402",
-    "browserStatus": "Beta: requires @fastnear/near-connect 0.13+ and a wallet that advertises both timeout-aware delegate-signing capabilities; production wallet manifest activation remains QA-gated.",
+    "browserStatus": "Stable with tested Meteor Wallet support; other wallets must advertise both timeout-aware delegate-signing capabilities and pass the x402 testnet harness before being documented as compatible.",
     "walletFeatures": [
       "signDelegateActions",
       "signDelegateActionsWithTtl"
@@ -1978,7 +1978,7 @@
           "@fastnear/x402/node",
           "@fastnear/x402"
         ],
-        "status": "stable core path"
+        "status": "stable"
       },
       {
         "task": "Pay an x402 URL from a browser wallet",
@@ -1990,7 +1990,7 @@
           "@fastnear/wallet",
           "@fastnear/x402"
         ],
-        "status": "beta until Intear and Meteor production wallet QA pass"
+        "status": "stable with a compatible timeout-aware wallet; Meteor Wallet is the tested production path"
       },
       {
         "task": "Protect a seller resource",

--- a/recipes/index.json
+++ b/recipes/index.json
@@ -1241,7 +1241,7 @@
           "environment": "browserGlobal",
           "language": "js",
           "runnable": true,
-          "code": "const cu = near.utils.convertUnit;\n\nconst result = await nearWallet.signDelegateActions({\n  delegateActions: [\n    {\n      receiverId: \"berryclub.ek.near\",\n      actions: [\n        {\n          type: \"FunctionCall\",\n          methodName: \"draw\",\n          args: { pixels: [{ x: 10, y: 20, color: 65280 }] },\n          gas: cu(\"100 Tgas\"),\n          deposit: \"0\",\n        },\n      ],\n    },\n  ],\n});\n\nnear.print({\n  count: result.signedDelegateActions.length,\n  first_delegate_hash: result.signedDelegateActions[0]?.delegateHash,\n});"
+          "code": "const cu = near.utils.convertUnit;\n\nconst result = await nearWallet.signDelegateActions({\n  delegateActions: [\n    {\n      receiverId: \"berryclub.ek.near\",\n      actions: [\n        {\n          type: \"FunctionCall\",\n          methodName: \"draw\",\n          args: { pixels: [{ x: 10, y: 20, color: 65280 }] },\n          gas: cu(\"100 Tgas\"),\n          deposit: \"0\",\n        },\n      ],\n    },\n  ],\n});\n\nnear.print({\n  count: result.signedDelegateActions.length,\n  first_delegate_borsh_base64:\n    result.signedDelegateActions[0]?.borshSerializedBase64,\n});"
         },
         {
           "id": "esm",
@@ -1249,18 +1249,19 @@
           "environment": "esm",
           "language": "js",
           "runnable": true,
-          "code": "import * as near from \"@fastnear/api\";\nimport * as nearWallet from \"@fastnear/wallet\";\n\nnear.config({ apiKey: process.env.FASTNEAR_API_KEY || undefined });\nnear.useWallet(nearWallet);\nawait nearWallet.restore({\n  network: \"mainnet\",\n  contractId: \"berryclub.ek.near\",\n  manifest: \"./manifest.json\",\n});\n\nconst cu = near.utils.convertUnit;\n\nconst result = await nearWallet.signDelegateActions({\n  delegateActions: [\n    {\n      receiverId: \"berryclub.ek.near\",\n      actions: [\n        {\n          type: \"FunctionCall\",\n          methodName: \"draw\",\n          args: { pixels: [{ x: 10, y: 20, color: 65280 }] },\n          gas: cu(\"100 Tgas\"),\n          deposit: \"0\",\n        },\n      ],\n    },\n  ],\n});\n\nnear.print({\n  count: result.signedDelegateActions.length,\n  first_delegate_hash: result.signedDelegateActions[0]?.delegateHash,\n});"
+          "code": "import * as near from \"@fastnear/api\";\nimport * as nearWallet from \"@fastnear/wallet\";\n\nnear.config({ apiKey: process.env.FASTNEAR_API_KEY || undefined });\nnear.useWallet(nearWallet);\nawait nearWallet.restore({\n  network: \"mainnet\",\n  contractId: \"berryclub.ek.near\",\n  manifest: \"./manifest.json\",\n});\n\nconst cu = near.utils.convertUnit;\n\nconst result = await nearWallet.signDelegateActions({\n  delegateActions: [\n    {\n      receiverId: \"berryclub.ek.near\",\n      actions: [\n        {\n          type: \"FunctionCall\",\n          methodName: \"draw\",\n          args: { pixels: [{ x: 10, y: 20, color: 65280 }] },\n          gas: cu(\"100 Tgas\"),\n          deposit: \"0\",\n        },\n      ],\n    },\n  ],\n});\n\nnear.print({\n  count: result.signedDelegateActions.length,\n  first_delegate_borsh_base64:\n    result.signedDelegateActions[0]?.borshSerializedBase64,\n});"
         }
       ],
       "service": "wallet",
       "returns": "SignDelegateActionsResponse",
       "outputKeys": [
-        "signedDelegateActions[].delegateHash",
-        "signedDelegateActions[].signedDelegate"
+        "signedDelegateActions[].borshSerializedBase64"
       ],
       "responseNotes": [
+        "The canonical result is { borshSerializedBase64: string }; legacy structured delegates and bare base64 strings remain in the public union for compatibility.",
         "Returns signed delegate actions that a relayer can submit on-chain, enabling gasless transactions for the user.",
-        "The wallet must support the signDelegateActions feature (check WalletFeatures.signDelegateActions)."
+        "The wallet must support the signDelegateActions feature (check WalletFeatures.signDelegateActions).",
+        "Requests that include blockHeightTtl additionally require WalletFeatures.signDelegateActionsWithTtl."
       ],
       "chooseWhen": [
         "Choose this when building gasless or relay-based flows where a third party submits the transaction on the user's behalf.",

--- a/recipes/source.mjs
+++ b/recipes/source.mjs
@@ -398,7 +398,8 @@ const result = await nearWallet.signDelegateActions({
 
 near.print({
   count: result.signedDelegateActions.length,
-  first_delegate_hash: result.signedDelegateActions[0]?.delegateHash,
+  first_delegate_borsh_base64:
+    result.signedDelegateActions[0]?.borshSerializedBase64,
 });`,
 
   ftBalance: `const balance = await near.ft.balance({
@@ -1391,12 +1392,13 @@ export const recipeCatalog = [
     service: "wallet",
     returns: "SignDelegateActionsResponse",
     outputKeys: [
-      "signedDelegateActions[].delegateHash",
-      "signedDelegateActions[].signedDelegate",
+      "signedDelegateActions[].borshSerializedBase64",
     ],
     responseNotes: [
+      "The canonical result is { borshSerializedBase64: string }; legacy structured delegates and bare base64 strings remain in the public union for compatibility.",
       "Returns signed delegate actions that a relayer can submit on-chain, enabling gasless transactions for the user.",
       "The wallet must support the signDelegateActions feature (check WalletFeatures.signDelegateActions).",
+      "Requests that include blockHeightTtl additionally require WalletFeatures.signDelegateActionsWithTtl.",
     ],
     chooseWhen: [
       "Choose this when building gasless or relay-based flows where a third party submits the transaction on the user's behalf.",

--- a/recipes/source.mjs
+++ b/recipes/source.mjs
@@ -1980,20 +1980,20 @@ export const x402Surface = {
     paymentAsset: "NEP-141 fungible tokens",
   },
   browserGlobal: "nearX402",
-  browserStatus: "Beta: requires @fastnear/near-connect 0.13+ and a wallet that advertises both timeout-aware delegate-signing capabilities; production wallet manifest activation remains QA-gated.",
+  browserStatus: "Stable with tested Meteor Wallet support; other wallets must advertise both timeout-aware delegate-signing capabilities and pass the x402 testnet harness before being documented as compatible.",
   walletFeatures: ["signDelegateActions", "signDelegateActionsWithTtl"],
   chooseByTask: [
     {
       task: "Pay an x402 URL from Node.js",
       use: ["createLocalNearSigner", "createNearPaymentFetch"],
       imports: ["@fastnear/x402/node", "@fastnear/x402"],
-      status: "stable core path",
+      status: "stable",
     },
     {
       task: "Pay an x402 URL from a browser wallet",
       use: ["createFastNearWalletSigner", "createNearPaymentFetch"],
       imports: ["@fastnear/wallet", "@fastnear/x402"],
-      status: "beta until Intear and Meteor production wallet QA pass",
+      status: "stable with a compatible timeout-aware wallet; Meteor Wallet is the tested production path",
     },
     {
       task: "Protect a seller resource",

--- a/recipes/source.mjs
+++ b/recipes/source.mjs
@@ -1961,12 +1961,144 @@ export async function findMlDsa65AccessKey({ accountId, publicKey }) {
   ],
 };
 
+/**
+ * The x402 surface is discovery metadata rather than a near.recipes.* entry.
+ * It spans four package exports and deliberately keeps server-only code out of
+ * the browser bundle.
+ */
+export const x402Surface = {
+  package: "@fastnear/x402",
+  runtime: "Package-only; not included in agents.js or near.js.",
+  guideUrl: "https://github.com/fastnear/js-monorepo/blob/main/packages/x402/README.md",
+  protocol: {
+    version: 2,
+    scheme: "exact",
+    networks: ["near:mainnet", "near:testnet"],
+    authorization: "NEP-366 SignedDelegate",
+    paymentAsset: "NEP-141 fungible tokens",
+  },
+  browserGlobal: "nearX402",
+  browserStatus: "Preview: requires a compatible upcoming near-connect release and a wallet that advertises timeout-aware delegate signing; the currently published wallet bridge is not production-compatible.",
+  walletFeatures: ["signDelegateActions", "signDelegateActionsWithTtl"],
+  chooseByTask: [
+    {
+      task: "Pay an x402 URL from Node.js",
+      use: ["createLocalNearSigner", "createNearPaymentFetch"],
+      imports: ["@fastnear/x402/node", "@fastnear/x402"],
+      status: "stable core path",
+    },
+    {
+      task: "Pay an x402 URL from a browser wallet",
+      use: ["createFastNearWalletSigner", "createNearPaymentFetch"],
+      imports: ["@fastnear/wallet", "@fastnear/x402"],
+      status: "preview until the timeout-aware wallet bridge ships",
+    },
+    {
+      task: "Protect a seller resource",
+      use: ["createNearResourceServer"],
+      imports: ["@fastnear/x402/server"],
+      status: "requires an explicit facilitator",
+    },
+    {
+      task: "Operate a NEAR facilitator",
+      use: ["createNearFacilitator"],
+      imports: ["@fastnear/x402/facilitator"],
+      status: "HTTP framework and secret storage are operator choices",
+    },
+    {
+      task: "Integrate below the paid-fetch helper",
+      use: ["createNearX402Client"],
+      imports: ["@fastnear/x402"],
+      status: "lower-level client path",
+    },
+  ],
+  entrypoints: [
+    {
+      subpath: "@fastnear/x402",
+      exports: [
+        "createFastNearWalletSigner",
+        "createNearX402Client",
+        "createNearPaymentFetch",
+      ],
+      purpose: "injected FastNEAR wallet signer, NEAR-only x402 client, and paid fetch",
+    },
+    {
+      subpath: "@fastnear/x402/node",
+      exports: ["createLocalNearSigner"],
+      purpose: "official RPC-backed local full-access-key signer",
+    },
+    {
+      subpath: "@fastnear/x402/server",
+      exports: ["createNearResourceServer"],
+      purpose: "resource server with one or more explicitly configured facilitators",
+    },
+    {
+      subpath: "@fastnear/x402/facilitator",
+      exports: ["createNearFacilitator"],
+      purpose: "self-hosted facilitator registration for concrete NEAR networks",
+    },
+  ],
+  constraints: [
+    "Only x402 v2 exact payments on near:mainnet and near:testnet are supported.",
+    "Payments use NEP-141 tokens; native NEAR is not a direct payment asset.",
+    "Wallet and local-key payers require full-access keys, and recipients need token storage registration.",
+    "Resource servers require an explicit facilitator; no x402.org or other default is selected.",
+    "Browser wallet access is injected explicitly and payment occurs only when the application calls the paid fetch function.",
+  ],
+  safeDefaults: [
+    "Pin near:testnet during development and a concrete NEAR network in production; use near:* only for an intentionally cross-network client.",
+    "Keep payer and relayer secret keys in server-side secret storage, never browser code.",
+    "String and number seller prices use the official USDC contract; wNEAR and custom tokens require an explicit { amount, asset } price.",
+    "Always configure a facilitator explicitly.",
+  ],
+  quickstarts: [
+    {
+      id: "x402-node-paid-fetch",
+      title: "Pay an x402 URL from Node.js",
+      summary: "Use the upstream local full-access-key signer with the high-level paid-fetch helper.",
+      language: "js",
+      code: `import { createNearPaymentFetch } from "@fastnear/x402";
+import { createLocalNearSigner } from "@fastnear/x402/node";
+
+const { NEAR_PAYER_ACCOUNT_ID, NEAR_PAYER_SECRET_KEY, X402_RESOURCE_URL } = process.env;
+if (!NEAR_PAYER_ACCOUNT_ID || !NEAR_PAYER_SECRET_KEY || !X402_RESOURCE_URL) {
+  throw new Error("NEAR_PAYER_ACCOUNT_ID, NEAR_PAYER_SECRET_KEY, and X402_RESOURCE_URL are required");
+}
+
+const signer = createLocalNearSigner({
+  accountId: NEAR_PAYER_ACCOUNT_ID,
+  secretKey: NEAR_PAYER_SECRET_KEY,
+  rpcUrls: { "near:testnet": "https://rpc.testnet.fastnear.com" },
+});
+const paidFetch = createNearPaymentFetch({ signer, network: "near:testnet" });
+const response = await paidFetch(X402_RESOURCE_URL);
+if (!response.ok) throw new Error(\`Paid request failed: \${response.status}\`);
+console.log(await response.json());`,
+    },
+    {
+      id: "x402-remote-facilitator-seller",
+      title: "Configure a seller with an explicit remote facilitator",
+      summary: "Create the NEAR resource-server core, then pass it to the x402 HTTP framework adapter you choose.",
+      language: "js",
+      code: `import { createNearResourceServer } from "@fastnear/x402/server";
+
+const { X402_FACILITATOR_URL } = process.env;
+if (!X402_FACILITATOR_URL) throw new Error("X402_FACILITATOR_URL is required");
+
+export const resourceServer = createNearResourceServer({
+  facilitators: { url: X402_FACILITATOR_URL },
+});
+await resourceServer.initialize();`,
+    },
+  ],
+};
+
 export const generatedArtifact = {
-  version: 4,
+  version: 5,
   homepage: FASTNEAR_CDN_BASE,
   source: "recipes/source.mjs",
   catalogUrl: FASTNEAR_RECIPE_CATALOG_ENTRY,
-  packages: ["@fastnear/api", "@fastnear/wallet", "@fastnear/utils", "@fastnear/ml-dsa-65"],
+  packages: ["@fastnear/api", "@fastnear/wallet", "@fastnear/utils", "@fastnear/ml-dsa-65", "@fastnear/x402"],
   support: supportSurface,
   families: familyCatalog,
   runtimes: {
@@ -2075,5 +2207,6 @@ export const generatedArtifact = {
   },
   recipes: recipeCatalog,
   mlDsa65: mlDsa65Surface,
+  x402: x402Surface,
   explain: explainSurface,
 };

--- a/recipes/source.mjs
+++ b/recipes/source.mjs
@@ -1980,7 +1980,7 @@ export const x402Surface = {
     paymentAsset: "NEP-141 fungible tokens",
   },
   browserGlobal: "nearX402",
-  browserStatus: "Preview: requires a compatible upcoming near-connect release and a wallet that advertises timeout-aware delegate signing; the currently published wallet bridge is not production-compatible.",
+  browserStatus: "Beta: requires @fastnear/near-connect 0.13+ and a wallet that advertises both timeout-aware delegate-signing capabilities; production wallet manifest activation remains QA-gated.",
   walletFeatures: ["signDelegateActions", "signDelegateActionsWithTtl"],
   chooseByTask: [
     {
@@ -1993,7 +1993,7 @@ export const x402Surface = {
       task: "Pay an x402 URL from a browser wallet",
       use: ["createFastNearWalletSigner", "createNearPaymentFetch"],
       imports: ["@fastnear/wallet", "@fastnear/x402"],
-      status: "preview until the timeout-aware wallet bridge ships",
+      status: "beta until Intear and Meteor production wallet QA pass",
     },
     {
       task: "Protect a seller resource",

--- a/scripts/check-bundle-sizes.mjs
+++ b/scripts/check-bundle-sizes.mjs
@@ -6,7 +6,8 @@ import { gzipSync } from "node:zlib";
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 // Clean-HEAD IIFE baselines measured with the repository's pinned esbuild and
-// gzip level 9. Existing packages may grow by at most 2 KiB minus one byte.
+// gzip level 9. Existing packages may grow by at most 2 KiB minus one byte by
+// default; feature-specific exceptions stay explicit in the table below.
 const maxExistingGzipGrowth = 2 * 1024 - 1;
 const budgets = [
   { package: "borsh", baselineGzip: 2_496 },
@@ -14,10 +15,11 @@ const budgets = [
   { package: "utils", baselineGzip: 35_696 },
   { package: "api", baselineGzip: 49_371 },
   { package: "wallet", baselineGzip: 21_323 },
-  // The timeout-aware Meteor bridge authenticates and binds returned Borsh
-  // delegates before exposing them to applications.
+  // The timeout-aware Meteor bridge includes local Borsh/action binding and
+  // signature verification before accepting a wallet response.
   { package: "wallet-adapter", baselineGzip: 41_529, maxGzipGrowth: 4 * 1024 - 1 },
   { package: "ml-dsa-65", raw: 75 * 1024, gzip: 20 * 1024 },
+  { package: "x402", raw: 256 * 1024, gzip: 64 * 1024 },
 ];
 
 const results = [];

--- a/scripts/generate-agent-artifacts.mjs
+++ b/scripts/generate-agent-artifacts.mjs
@@ -365,7 +365,7 @@ The monorepo now ships a low-level-first runtime plus a compact task catalog for
 - ` + "`near.explain.*`" + ` turns actions, transactions, and thrown errors into stable JSON summaries.
 - The original low-level entrypoints stay intact: ` + "`near.view`" + `, ` + "`near.queryAccount`" + `, ` + "`near.queryTx`" + `, ` + "`near.sendTx`" + `, ` + "`near.requestSignIn`" + `, and ` + "`near.signMessage`" + `.
 - ` + "`near.batch(...)`" + ` and ` + "`near.view.many(...)`" + ` fan out many reads with settled, concurrency-capped results, and ` + "`near.config({ retry, batch })`" + ` tunes automatic 429/transient retry — both on by default. See the API package README for details.
-- ` + "`@fastnear/x402`" + ` provides opt-in x402 v2 NEAR payment clients plus focused ` + "`/node`" + `, ` + "`/server`" + `, and ` + "`/facilitator`" + ` entrypoints; its browser-wallet path is beta while wallet production manifests remain QA-gated.
+- ` + "`@fastnear/x402`" + ` provides opt-in x402 v2 NEAR payment clients plus focused ` + "`/node`" + `, ` + "`/server`" + `, and ` + "`/facilitator`" + ` entrypoints; browser-wallet payments require a timeout-aware wallet, with Meteor Wallet tested for this release.
 
 ### Hosted agent entrypoint
 

--- a/scripts/generate-agent-artifacts.mjs
+++ b/scripts/generate-agent-artifacts.mjs
@@ -365,7 +365,7 @@ The monorepo now ships a low-level-first runtime plus a compact task catalog for
 - ` + "`near.explain.*`" + ` turns actions, transactions, and thrown errors into stable JSON summaries.
 - The original low-level entrypoints stay intact: ` + "`near.view`" + `, ` + "`near.queryAccount`" + `, ` + "`near.queryTx`" + `, ` + "`near.sendTx`" + `, ` + "`near.requestSignIn`" + `, and ` + "`near.signMessage`" + `.
 - ` + "`near.batch(...)`" + ` and ` + "`near.view.many(...)`" + ` fan out many reads with settled, concurrency-capped results, and ` + "`near.config({ retry, batch })`" + ` tunes automatic 429/transient retry — both on by default. See the API package README for details.
-- ` + "`@fastnear/x402`" + ` provides opt-in x402 v2 NEAR payment clients plus focused ` + "`/node`" + `, ` + "`/server`" + `, and ` + "`/facilitator`" + ` entrypoints; its browser-wallet path is a preview pending the timeout-aware wallet bridge.
+- ` + "`@fastnear/x402`" + ` provides opt-in x402 v2 NEAR payment clients plus focused ` + "`/node`" + `, ` + "`/server`" + `, and ` + "`/facilitator`" + ` entrypoints; its browser-wallet path is beta while wallet production manifests remain QA-gated.
 
 ### Hosted agent entrypoint
 

--- a/scripts/generate-agent-artifacts.mjs
+++ b/scripts/generate-agent-artifacts.mjs
@@ -9,6 +9,7 @@ import {
   recipeCatalog,
   explainSurface,
   mlDsa65Surface,
+  x402Surface,
   supportSurface,
 } from "../recipes/source.mjs";
 
@@ -38,8 +39,8 @@ function renderPagination(pagination) {
 }
 
 function assertCatalogContract() {
-  if (generatedArtifact.version !== 4) {
-    throw new Error(`Expected generated artifact version 4, received ${generatedArtifact.version}`);
+  if (generatedArtifact.version !== 5) {
+    throw new Error(`Expected generated artifact version 5, received ${generatedArtifact.version}`);
   }
 
   if (!Array.isArray(generatedArtifact.families) || generatedArtifact.families.length < 6) {
@@ -73,6 +74,21 @@ function assertCatalogContract() {
       if (!(field in quickstart)) {
         throw new Error(`ML-DSA-65 quickstart ${quickstart.id ?? "<unknown>"} is missing required field ${field}`);
       }
+    }
+  }
+
+  if (x402Surface.package !== "@fastnear/x402" || x402Surface.browserGlobal !== "nearX402") {
+    throw new Error("Expected canonical @fastnear/x402 package and browser global metadata");
+  }
+  if (x402Surface.entrypoints.length !== 4) {
+    throw new Error("Expected four focused @fastnear/x402 entrypoints");
+  }
+  if (x402Surface.chooseByTask.length !== 5 || x402Surface.quickstarts.length !== 2) {
+    throw new Error("Expected the x402 task chooser and two focused quickstarts");
+  }
+  for (const feature of ["signDelegateActions", "signDelegateActionsWithTtl"]) {
+    if (!x402Surface.walletFeatures.includes(feature)) {
+      throw new Error(`Expected x402 wallet feature ${feature}`);
     }
   }
 }
@@ -148,6 +164,49 @@ ${renderList(mlDsa65Surface.safety)}
 ${mlDsa65Surface.quickstarts.map((quickstart) => `${subheading} ${quickstart.title}
 
 Recipe ID: \`${quickstart.id}\`
+
+${quickstart.summary}
+
+\`\`\`${quickstart.language}
+${quickstart.code}
+\`\`\``).join("\n\n")}`;
+}
+
+function renderX402Section({ headingLevel = 3 } = {}) {
+  const heading = "#".repeat(headingLevel);
+  const subheading = "#".repeat(headingLevel + 1);
+
+  return `${heading} x402 payments on NEAR
+
+\`${x402Surface.package}\` adapts the official x402 Foundation NEAR mechanism without introducing another wire format.
+
+- Protocol: x402 v${x402Surface.protocol.version} \`${x402Surface.protocol.scheme}\` on ${x402Surface.protocol.networks.map(network => `\`${network}\``).join(" and ")}.
+- Authorization: ${x402Surface.protocol.authorization}; asset: ${x402Surface.protocol.paymentAsset}.
+- Browser global: \`${x402Surface.browserGlobal}\`.
+- Runtime: ${x402Surface.runtime}
+- Browser status: ${x402Surface.browserStatus}
+- Required wallet features: ${x402Surface.walletFeatures.map(feature => `\`${feature}\``).join(" and ")}.
+- Package guide: [${x402Surface.guideUrl}](${x402Surface.guideUrl}).
+
+${subheading} Choose by task
+
+${renderList(x402Surface.chooseByTask.map(choice => `${choice.task}: ${choice.use.map(name => `\`${name}\``).join(" + ")} from ${choice.imports.map(name => `\`${name}\``).join(" and ")} — ${choice.status}.`))}
+
+${subheading} Entrypoints
+
+${renderList(x402Surface.entrypoints.map(entry => `\`${entry.subpath}\`: ${entry.exports.map(name => `\`${name}\``).join(", ")} — ${entry.purpose}.`))}
+
+${subheading} Constraints
+
+${renderList(x402Surface.constraints)}
+
+${subheading} Safe defaults
+
+${renderList(x402Surface.safeDefaults)}
+
+${x402Surface.quickstarts.map(quickstart => `${subheading} ${quickstart.title}
+
+Quickstart ID: \`${quickstart.id}\`
 
 ${quickstart.summary}
 
@@ -261,6 +320,7 @@ The monorepo now ships a low-level-first runtime plus a compact task catalog for
 - ` + "`near.explain.*`" + ` turns actions, transactions, and thrown errors into stable JSON summaries.
 - The original low-level entrypoints stay intact: ` + "`near.view`" + `, ` + "`near.queryAccount`" + `, ` + "`near.queryTx`" + `, ` + "`near.sendTx`" + `, ` + "`near.requestSignIn`" + `, and ` + "`near.signMessage`" + `.
 - ` + "`near.batch(...)`" + ` and ` + "`near.view.many(...)`" + ` fan out many reads with settled, concurrency-capped results, and ` + "`near.config({ retry, batch })`" + ` tunes automatic 429/transient retry — both on by default. See the API package README for details.
+- ` + "`@fastnear/x402`" + ` provides opt-in x402 v2 NEAR payment clients plus focused ` + "`/node`" + `, ` + "`/server`" + `, and ` + "`/facilitator`" + ` entrypoints; its browser-wallet path is a preview pending the timeout-aware wallet bridge.
 
 ### Hosted agent entrypoint
 
@@ -289,6 +349,8 @@ ${terminal.code}
   }).join("\n\n")}
 
 ${renderMlDsa65Section()}
+
+${renderX402Section()}
 
 ### Structured explain helpers
 
@@ -498,6 +560,7 @@ Primary packages:
 - @fastnear/wallet
 - @fastnear/utils
 - @fastnear/ml-dsa-65
+- @fastnear/x402
 
 Low-level-first runtime surfaces:
 - near.config({ apiKey })
@@ -545,7 +608,7 @@ Wallet runtime surfaces (@fastnear/wallet):
 - nearWallet.sendTransaction({ receiverId, actions, network })
 - nearWallet.sendTransactions({ transactions, network })
 - nearWallet.signMessage({ message, recipient, nonce, network })
-- nearWallet.signDelegateActions({ delegateActions, signerId, network })
+- nearWallet.signDelegateActions({ delegateActions: [{ ..., blockHeightTtl }], signerId, network }) — timeout-aware requests require signDelegateActionsWithTtl
 - nearWallet.addFunctionCallKey({ contractId, methodNames, allowance, network })
 - nearWallet.accountId({ network })
 - nearWallet.isConnected({ network })
@@ -553,6 +616,19 @@ Wallet runtime surfaces (@fastnear/wallet):
 - nearWallet.switchNetwork(network)
 - nearWallet.onConnect(handler)
 - nearWallet.onDisconnect(handler)
+
+x402 payment surface (@fastnear/x402):
+- Runtime: ${x402Surface.runtime}
+- Protocol: x402 v${x402Surface.protocol.version} ${x402Surface.protocol.scheme}; networks: ${x402Surface.protocol.networks.join(", ")}; asset: ${x402Surface.protocol.paymentAsset}
+- Pay a URL in Node: ${x402Surface.chooseByTask[0].use.join(" + ")} (${x402Surface.chooseByTask[0].imports.join(" + ")})
+- Protect a seller resource: ${x402Surface.chooseByTask[2].use.join(" + ")} (${x402Surface.chooseByTask[2].imports.join(" + ")}); explicit facilitator required
+- Browser: ${x402Surface.entrypoints[0].exports.join(" / ")} (global ${x402Surface.browserGlobal})
+- Node: @fastnear/x402/node ${x402Surface.entrypoints[1].exports.join(" / ")}
+- Seller: @fastnear/x402/server ${x402Surface.entrypoints[2].exports.join(" / ")}; explicit facilitator required
+- Self-hosted facilitator: @fastnear/x402/facilitator ${x402Surface.entrypoints[3].exports.join(" / ")}
+- Wallet features: ${x402Surface.walletFeatures.join(" + ")}
+- Status: ${x402Surface.browserStatus}
+- Guide: ${x402Surface.guideUrl}
 
 Named endpoint response types:
 - FastNearRecipeDiscoveryEntry
@@ -608,6 +684,7 @@ Prefer ` + "`recipes/index.json`" + ` when you need structured task data.
 - ` + "`@fastnear/wallet`" + `: wallet connection and transaction/signing provider
 - ` + "`@fastnear/utils`" + `: units, crypto, serialization, storage helpers
 - ` + "`@fastnear/ml-dsa-65`" + `: opt-in protocol-v85 ML-DSA-65 account-key generation, encoding, hashing, and transaction signing
+- ` + "`@fastnear/x402`" + `: official x402 v2 NEAR adapters for paid fetch, local-key clients, resource servers, and facilitators
 
 ## Unified config
 
@@ -673,7 +750,7 @@ ${renderList(family.entrypoints.map((entrypoint) => `\`${entrypoint}\``))}
 - ` + "`nearWallet.connect`" + ` / ` + "`disconnect`" + ` / ` + "`restore`" + `: open, close, or rehydrate a session per network. ` + "`connect({ network, contractId, manifest })`" + ` is the canonical entrypoint; ` + "`contractId`" + ` mints a function-call key scoped to that contract so zero-deposit calls sign silently.
 - ` + "`nearWallet.sendTransaction({ receiverId, actions, network })`" + ` / ` + "`sendTransactions`" + `: dispatch one or many transactions through the connected wallet on the chosen network.
 - ` + "`nearWallet.signMessage({ message, recipient, nonce, network })`" + `: NEP-413 message signing.
-- ` + "`nearWallet.signDelegateActions({ delegateActions, signerId?, network? })`" + `: sign NEP-366 delegate actions for gasless relay-based flows. Returns ` + "`{ signedDelegateActions: Array<{ delegateHash: Uint8Array; signedDelegate: SignedDelegate }> }`" + `.
+- ` + "`nearWallet.signDelegateActions({ delegateActions, signerId?, network? })`" + `: sign NEP-366 delegate actions for gasless relay-based flows. Each request may include ` + "`blockHeightTtl`" + `; using it requires a wallet that advertises ` + "`signDelegateActionsWithTtl`" + `. The canonical transport result is ` + "`{ borshSerializedBase64: string }`" + `, while legacy structured and bare-base64 results remain accepted during the bridge transition.
 - ` + "`nearWallet.addFunctionCallKey({ contractId, methodNames, allowance, network })`" + ` (` + "`@fastnear/wallet@1.1.4+`" + `): grant a second function-call key on another contract after sign-in, so a follow-on zero-deposit call to that contract also signs silently.
 - ` + "`nearWallet.accountId`" + ` / ` + "`isConnected`" + ` / ` + "`connectedNetworks`" + ` / ` + "`switchNetwork`" + `: per-network session inspection and the active-network cursor.
 - ` + "`nearWallet.onConnect`" + ` / ` + "`onDisconnect`" + `: subscribe to session lifecycle.
@@ -698,6 +775,8 @@ ${supportSurface.captureExample.summary}
 \`\`\`${supportSurface.captureExample.language}
 ${supportSurface.captureExample.code}
 \`\`\`
+
+${renderX402Section({ headingLevel: 2 })}
 
 ${renderMlDsa65Section({ headingLevel: 2 })}
 

--- a/scripts/generate-agent-artifacts.mjs
+++ b/scripts/generate-agent-artifacts.mjs
@@ -86,6 +86,51 @@ function assertCatalogContract() {
   if (x402Surface.chooseByTask.length !== 5 || x402Surface.quickstarts.length !== 2) {
     throw new Error("Expected the x402 task chooser and two focused quickstarts");
   }
+
+  const expectedX402Entrypoints = new Map([
+    [
+      "@fastnear/x402",
+      ["createFastNearWalletSigner", "createNearX402Client", "createNearPaymentFetch"],
+    ],
+    ["@fastnear/x402/node", ["createLocalNearSigner"]],
+    ["@fastnear/x402/server", ["createNearResourceServer"]],
+    ["@fastnear/x402/facilitator", ["createNearFacilitator"]],
+  ]);
+  for (const [subpath, expectedExports] of expectedX402Entrypoints) {
+    const entrypoint = x402Surface.entrypoints.find(entry => entry.subpath === subpath);
+    if (!entrypoint || JSON.stringify(entrypoint.exports) !== JSON.stringify(expectedExports)) {
+      throw new Error(`Expected canonical x402 exports for ${subpath}`);
+    }
+  }
+
+  const expectedX402Tasks = new Map([
+    ["Pay an x402 URL from Node.js", ["createLocalNearSigner", "createNearPaymentFetch"]],
+    ["Pay an x402 URL from a browser wallet", ["createFastNearWalletSigner", "createNearPaymentFetch"]],
+    ["Protect a seller resource", ["createNearResourceServer"]],
+    ["Operate a NEAR facilitator", ["createNearFacilitator"]],
+    ["Integrate below the paid-fetch helper", ["createNearX402Client"]],
+  ]);
+  for (const [task, expectedFactories] of expectedX402Tasks) {
+    const choice = x402Surface.chooseByTask.find(item => item.task === task);
+    if (!choice || JSON.stringify(choice.use) !== JSON.stringify(expectedFactories)) {
+      throw new Error(`Expected canonical x402 task mapping for ${task}`);
+    }
+  }
+
+  const quickstartIds = new Set(x402Surface.quickstarts.map(quickstart => quickstart.id));
+  for (const id of ["x402-node-paid-fetch", "x402-remote-facilitator-seller"]) {
+    if (!quickstartIds.has(id)) {
+      throw new Error(`Expected x402 quickstart ${id}`);
+    }
+  }
+  for (const phrase of ["Only x402 v2 exact", "NEP-141", "explicit facilitator"]) {
+    if (!x402Surface.constraints.some(constraint => constraint.includes(phrase))) {
+      throw new Error(`Expected x402 constraint containing ${phrase}`);
+    }
+  }
+  if (!/^https:\/\/.+/.test(x402Surface.guideUrl)) {
+    throw new Error("Expected an absolute x402 package guide URL");
+  }
   for (const feature of ["signDelegateActions", "signDelegateActionsWithTtl"]) {
     if (!x402Surface.walletFeatures.includes(feature)) {
       throw new Error(`Expected x402 wallet feature ${feature}`);

--- a/scripts/published-x402-helpers.mjs
+++ b/scripts/published-x402-helpers.mjs
@@ -1,0 +1,364 @@
+import { Buffer } from "node:buffer";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { gunzipSync } from "node:zlib";
+import vm from "node:vm";
+
+const EXACT_SEMVER =
+  /^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+const ROOT_FACTORIES = [
+  "createFastNearWalletSigner",
+  "createNearPaymentFetch",
+  "createNearX402Client",
+];
+
+const SERVER_ONLY_FACTORIES = [
+  "createLocalNearSigner",
+  "createNearResourceServer",
+  "createNearFacilitator",
+];
+
+const NODE_ENTRYPOINTS = [
+  ["@fastnear/x402", ROOT_FACTORIES],
+  ["@fastnear/x402/node", ["createLocalNearSigner"]],
+  ["@fastnear/x402/server", ["createNearResourceServer"]],
+  ["@fastnear/x402/facilitator", ["createNearFacilitator"]],
+];
+
+export function exactPublishedVersion(value) {
+  if (typeof value !== "string" || !EXACT_SEMVER.test(value)) {
+    throw new Error(
+      "Published x402 verification requires one exact semver such as 1.5.0 or 1.5.0-beta.0",
+    );
+  }
+  return value;
+}
+
+export function assertTarballIntegrity(tarball, integrity, shasum) {
+  if (typeof integrity !== "string" || integrity.length === 0) {
+    throw new Error("npm metadata is missing dist.integrity");
+  }
+
+  const supported = new Set(["sha256", "sha384", "sha512"]);
+  const matchesIntegrity = integrity.split(/\s+/).some((entry) => {
+    const separator = entry.indexOf("-");
+    if (separator < 1) return false;
+    const algorithm = entry.slice(0, separator);
+    if (!supported.has(algorithm)) return false;
+    const expected = entry.slice(separator + 1).split("?")[0];
+    return createHash(algorithm).update(tarball).digest("base64") === expected;
+  });
+  if (!matchesIntegrity) {
+    throw new Error("npm tarball bytes do not match dist.integrity");
+  }
+
+  if (
+    typeof shasum === "string" &&
+    createHash("sha1").update(tarball).digest("hex") !== shasum
+  ) {
+    throw new Error("npm tarball bytes do not match dist.shasum");
+  }
+}
+
+function tarString(tar, offset, length) {
+  const end = tar.indexOf(0, offset);
+  const boundedEnd = end === -1 || end > offset + length ? offset + length : end;
+  return tar.subarray(offset, boundedEnd).toString("utf8").trim();
+}
+
+export function extractTarEntry(tarball, expectedName) {
+  const tar = gunzipSync(tarball);
+  let offset = 0;
+
+  while (offset + 512 <= tar.length) {
+    const header = tar.subarray(offset, offset + 512);
+    if (header.every((byte) => byte === 0)) break;
+
+    const name = tarString(header, 0, 100);
+    const prefix = tarString(header, 345, 155);
+    const fullName = prefix ? `${prefix}/${name}` : name;
+    const sizeSource = tarString(header, 124, 12);
+    if (!/^[0-7]+$/.test(sizeSource)) {
+      throw new Error(`Unsupported tar size for ${fullName || "unnamed entry"}`);
+    }
+    const size = Number.parseInt(sizeSource, 8);
+    const contentsOffset = offset + 512;
+    if (!Number.isSafeInteger(size) || contentsOffset + size > tar.length) {
+      throw new Error(`Invalid tar entry size for ${fullName || "unnamed entry"}`);
+    }
+    if (fullName === expectedName) {
+      return tar.subarray(contentsOffset, contentsOffset + size);
+    }
+
+    offset = contentsOffset + Math.ceil(size / 512) * 512;
+  }
+
+  throw new Error(`npm tarball is missing ${expectedName}`);
+}
+
+function exportTarget(manifest, exportPath, condition) {
+  let target = manifest.exports?.[exportPath];
+  while (target && typeof target === "object") {
+    target = target[condition] ?? target.default;
+  }
+  if (typeof target !== "string") {
+    throw new Error(
+      `Published @fastnear/x402 is missing ${condition} for export ${exportPath}`,
+    );
+  }
+  return target;
+}
+
+function assertPackedSurface(tarball, manifest, version) {
+  if (manifest.name !== "@fastnear/x402" || manifest.version !== version) {
+    throw new Error(
+      `npm tarball identity mismatch: ${manifest.name ?? "unknown"}@${manifest.version ?? "unknown"}`,
+    );
+  }
+  if (manifest.peerDependencies?.["@fastnear/wallet"] !== version) {
+    throw new Error(
+      "Published @fastnear/x402 wallet peer does not match its synchronized version",
+    );
+  }
+  if (manifest.peerDependenciesMeta?.["@fastnear/wallet"]?.optional !== true) {
+    throw new Error("Published @fastnear/x402 wallet peer is not optional");
+  }
+  for (const [name, range] of Object.entries(manifest.dependencies ?? {})) {
+    if (range === "*" || String(range).startsWith("workspace:")) {
+      throw new Error(`Published @fastnear/x402 leaked dependency ${name}: ${range}`);
+    }
+  }
+
+  const targets = new Set([
+    manifest.main,
+    manifest.module,
+    manifest.types,
+    manifest.browser,
+  ]);
+  for (const exportPath of [".", "./node", "./server", "./facilitator"]) {
+    for (const condition of ["require", "import", "types"]) {
+      targets.add(exportTarget(manifest, exportPath, condition));
+    }
+  }
+  for (const target of targets) {
+    if (typeof target !== "string" || !target.startsWith("./")) {
+      throw new Error(`Published @fastnear/x402 has an invalid package target: ${target}`);
+    }
+    extractTarEntry(tarball, `package/${target.slice(2)}`);
+  }
+}
+
+function inspectPublishedIife(source) {
+  const storage = new Map();
+  const sandbox = {
+    console,
+    TextEncoder,
+    TextDecoder,
+    URL,
+    URLSearchParams,
+    Uint8Array,
+    ArrayBuffer,
+    DataView,
+    setTimeout,
+    clearTimeout,
+    crypto: globalThis.crypto,
+    fetch: globalThis.fetch,
+    atob: globalThis.atob,
+    btoa: globalThis.btoa,
+    Headers: globalThis.Headers,
+    Request: globalThis.Request,
+    Response: globalThis.Response,
+    navigator: { userAgent: "fastnear-published-x402-smoke" },
+    localStorage: {
+      getItem: (key) => storage.get(key) ?? null,
+      setItem: (key, value) => storage.set(key, String(value)),
+      removeItem: (key) => storage.delete(key),
+      clear: () => storage.clear(),
+    },
+  };
+  sandbox.globalThis = sandbox;
+  sandbox.window = sandbox;
+  sandbox.self = sandbox;
+
+  vm.runInNewContext(source, sandbox, { filename: "@fastnear/x402 IIFE" });
+  const descriptor = Object.getOwnPropertyDescriptor(sandbox, "nearX402");
+  if (!descriptor || descriptor.configurable !== false) {
+    throw new Error("Published IIFE did not lock globalThis.nearX402");
+  }
+  for (const factory of ROOT_FACTORIES) {
+    if (typeof sandbox.nearX402?.[factory] !== "function") {
+      throw new Error(`Published IIFE is missing ${factory}`);
+    }
+  }
+  for (const factory of SERVER_ONLY_FACTORIES) {
+    if (factory in sandbox.nearX402) {
+      throw new Error(`Published IIFE leaked server-only export ${factory}`);
+    }
+  }
+}
+
+function verifyPublishedNodeImports(tarball, version) {
+  const temporaryRoot = mkdtempSync(
+    path.join(os.tmpdir(), "fastnear-published-x402-"),
+  );
+  try {
+    const tarballPath = path.join(temporaryRoot, `fastnear-x402-${version}.tgz`);
+    writeFileSync(tarballPath, tarball);
+    writeFileSync(
+      path.join(temporaryRoot, "package.json"),
+      `${JSON.stringify({
+        name: "fastnear-published-x402-acceptance",
+        version: "0.0.0",
+        private: true,
+        type: "module",
+      }, null, 2)}\n`,
+    );
+
+    const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+    const install = spawnSync(
+      npm,
+      [
+        "install",
+        "--ignore-scripts",
+        "--no-audit",
+        "--no-fund",
+        "--package-lock=false",
+        tarballPath,
+      ],
+      {
+        cwd: temporaryRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          npm_config_update_notifier: "false",
+        },
+        maxBuffer: 16 * 1024 * 1024,
+      },
+    );
+    if (install.error) throw install.error;
+    if (install.status !== 0) {
+      throw new Error(
+        `Failed to install the verified npm tarball:\n${install.stdout ?? ""}${install.stderr ?? ""}`,
+      );
+    }
+    if (existsSync(path.join(temporaryRoot, "node_modules/@fastnear/wallet"))) {
+      throw new Error(
+        "Published @fastnear/x402 installed its optional wallet peer in a server consumer",
+      );
+    }
+
+    const importSmoke = `
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+const entrypoints = ${JSON.stringify(NODE_ENTRYPOINTS)};
+const runtimeKeys = (namespace) => Object.keys(namespace)
+  .filter((key) => key !== "default" && key !== "__esModule")
+  .sort();
+for (const [specifier, probes] of entrypoints) {
+  const cjs = require(specifier);
+  const esm = await import(specifier);
+  assert.deepEqual(runtimeKeys(cjs), runtimeKeys(esm), specifier + " export mismatch");
+  for (const probe of probes) {
+    assert.equal(typeof cjs[probe], "function", specifier + " require() missed " + probe);
+    assert.equal(typeof esm[probe], "function", specifier + " import missed " + probe);
+  }
+}
+`;
+    const smoke = spawnSync(
+      process.execPath,
+      ["--input-type=module", "--eval", importSmoke],
+      {
+        cwd: temporaryRoot,
+        encoding: "utf8",
+        maxBuffer: 16 * 1024 * 1024,
+      },
+    );
+    if (smoke.error) throw smoke.error;
+    if (smoke.status !== 0) {
+      throw new Error(
+        `Published CJS/ESM entrypoint smoke failed:\n${smoke.stdout ?? ""}${smoke.stderr ?? ""}`,
+      );
+    }
+  } finally {
+    rmSync(temporaryRoot, { recursive: true, force: true });
+  }
+}
+
+async function fetchBytes(fetchImpl, url, label) {
+  const response = await fetchImpl(url, {
+    headers: { "user-agent": "fastnear-published-x402-verifier" },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch ${label} from ${url}: ${response.status} ${response.statusText}`,
+    );
+  }
+  return Buffer.from(await response.arrayBuffer());
+}
+
+export async function verifyPublishedX402(versionInput, fetchImpl = globalThis.fetch) {
+  const version = exactPublishedVersion(versionInput);
+  if (typeof fetchImpl !== "function") {
+    throw new Error("A fetch implementation is required");
+  }
+
+  const metadataUrl =
+    `https://registry.npmjs.org/@fastnear%2Fx402/${encodeURIComponent(version)}`;
+  const metadataBytes = await fetchBytes(fetchImpl, metadataUrl, "npm metadata");
+  let metadata;
+  try {
+    metadata = JSON.parse(metadataBytes.toString("utf8"));
+  } catch {
+    throw new Error("npm returned malformed @fastnear/x402 metadata");
+  }
+  if (metadata.name !== "@fastnear/x402" || metadata.version !== version) {
+    throw new Error("npm metadata did not resolve the requested exact version");
+  }
+  if (typeof metadata.dist?.tarball !== "string") {
+    throw new Error("npm metadata is missing dist.tarball");
+  }
+
+  const tarball = await fetchBytes(fetchImpl, metadata.dist.tarball, "npm tarball");
+  assertTarballIntegrity(tarball, metadata.dist.integrity, metadata.dist.shasum);
+
+  const packageJson = extractTarEntry(tarball, "package/package.json");
+  let manifest;
+  try {
+    manifest = JSON.parse(packageJson.toString("utf8"));
+  } catch {
+    throw new Error("npm tarball contains malformed package.json");
+  }
+  assertPackedSurface(tarball, manifest, version);
+
+  const npmIife = extractTarEntry(
+    tarball,
+    "package/dist/umd/browser.global.js",
+  );
+  const cdnUrl =
+    `https://cdn.jsdelivr.net/npm/@fastnear/x402@${encodeURIComponent(version)}/dist/umd/browser.global.js`;
+  const cdnIife = await fetchBytes(fetchImpl, cdnUrl, "immutable jsDelivr IIFE");
+  if (!npmIife.equals(cdnIife)) {
+    throw new Error("jsDelivr IIFE bytes differ from the immutable npm tarball");
+  }
+  inspectPublishedIife(cdnIife.toString("utf8"));
+  verifyPublishedNodeImports(tarball, version);
+
+  return {
+    version,
+    metadataUrl,
+    tarballUrl: metadata.dist.tarball,
+    cdnUrl,
+    iifeBytes: cdnIife.length,
+    nodeEntrypoints: NODE_ENTRYPOINTS.length,
+  };
+}

--- a/scripts/published-x402-helpers.test.mjs
+++ b/scripts/published-x402-helpers.test.mjs
@@ -1,0 +1,194 @@
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+import { gzipSync } from "node:zlib";
+import { describe, expect, it } from "vitest";
+import {
+  assertTarballIntegrity,
+  exactPublishedVersion,
+  extractTarEntry,
+  verifyPublishedX402,
+} from "./published-x402-helpers.mjs";
+
+function tarHeader(name, size) {
+  const header = Buffer.alloc(512);
+  header.write(name, 0, 100, "utf8");
+  header.write("0000644\0", 100, 8, "ascii");
+  header.write("0000000\0", 108, 8, "ascii");
+  header.write("0000000\0", 116, 8, "ascii");
+  header.write(`${size.toString(8).padStart(11, "0")}\0`, 124, 12, "ascii");
+  header.write("00000000000\0", 136, 12, "ascii");
+  header.fill(0x20, 148, 156);
+  header.write("0", 156, 1, "ascii");
+  header.write("ustar\0", 257, 6, "ascii");
+  header.write("00", 263, 2, "ascii");
+  const checksum = header.reduce((sum, byte) => sum + byte, 0);
+  header.write(`${checksum.toString(8).padStart(6, "0")}\0 `, 148, 8, "ascii");
+  return header;
+}
+
+function makeTarball(entries) {
+  const parts = [];
+  for (const [name, value] of entries) {
+    const body = Buffer.from(value);
+    parts.push(tarHeader(name, body.length), body);
+    const padding = (512 - (body.length % 512)) % 512;
+    if (padding) parts.push(Buffer.alloc(padding));
+  }
+  parts.push(Buffer.alloc(1024));
+  return gzipSync(Buffer.concat(parts));
+}
+
+const version = "1.5.0-beta.0";
+const iife = `var nearX402 = {
+  createFastNearWalletSigner() {},
+  createNearPaymentFetch() {},
+  createNearX402Client() {},
+};
+Object.defineProperty(globalThis, "nearX402", {
+  value: nearX402,
+  enumerable: true,
+  configurable: false,
+});
+`;
+
+function fixtureModuleSource(target) {
+  if (target.endsWith("/browser.global.js")) return iife;
+  const probes = target.includes("/facilitator.")
+    ? ["createNearFacilitator"]
+    : target.includes("/server.")
+      ? ["createNearResourceServer"]
+      : target.includes("/node.")
+        ? ["createLocalNearSigner"]
+        : [
+            "createFastNearWalletSigner",
+            "createNearPaymentFetch",
+            "createNearX402Client",
+          ];
+  if (target.endsWith(".cjs")) {
+    return probes.map((probe) => `exports.${probe} = function ${probe}() {};`).join("\n");
+  }
+  return probes.map((probe) => `export function ${probe}() {}`).join("\n");
+}
+
+function fixture() {
+  const manifest = {
+    name: "@fastnear/x402",
+    version,
+    main: "./dist/cjs/index.cjs",
+    module: "./dist/esm/index.js",
+    types: "./dist/esm/index.d.ts",
+    browser: "./dist/umd/browser.global.js",
+    exports: {
+      ".": {
+        require: "./dist/cjs/index.cjs",
+        import: "./dist/esm/index.js",
+        types: "./dist/esm/index.d.ts",
+      },
+      "./node": {
+        require: "./dist/cjs/node.cjs",
+        import: "./dist/esm/node.js",
+        types: "./dist/esm/node.d.ts",
+      },
+      "./server": {
+        require: "./dist/cjs/server.cjs",
+        import: "./dist/esm/server.js",
+        types: "./dist/esm/server.d.ts",
+      },
+      "./facilitator": {
+        require: "./dist/cjs/facilitator.cjs",
+        import: "./dist/esm/facilitator.js",
+        types: "./dist/esm/facilitator.d.ts",
+      },
+    },
+    peerDependencies: { "@fastnear/wallet": "1.5.0-beta.0" },
+    peerDependenciesMeta: { "@fastnear/wallet": { optional: true } },
+  };
+  const files = new Set([
+    manifest.main,
+    manifest.module,
+    manifest.types,
+    manifest.browser,
+  ]);
+  for (const entry of Object.values(manifest.exports)) {
+    for (const target of Object.values(entry)) files.add(target);
+  }
+  const tarball = makeTarball([
+    ["package/package.json", `${JSON.stringify(manifest)}\n`],
+    ...[...files].map((target) => [
+      `package/${target.slice(2)}`,
+      fixtureModuleSource(target),
+    ]),
+  ]);
+  const integrity = `sha512-${createHash("sha512").update(tarball).digest("base64")}`;
+  const shasum = createHash("sha1").update(tarball).digest("hex");
+  const tarballUrl =
+    `https://registry.npmjs.org/@fastnear/x402/-/x402-${version}.tgz`;
+  const metadata = {
+    name: "@fastnear/x402",
+    version,
+    dist: { tarball: tarballUrl, integrity, shasum },
+  };
+  return { tarball, tarballUrl, metadata };
+}
+
+describe("published x402 verifier", () => {
+  it("accepts only an exact semver", () => {
+    expect(exactPublishedVersion("1.5.0")).toBe("1.5.0");
+    expect(exactPublishedVersion(version)).toBe(version);
+    for (const invalid of ["latest", "next", "^1.5.0", "v1.5.0", "1.5"]) {
+      expect(() => exactPublishedVersion(invalid), invalid).toThrow("exact semver");
+    }
+  });
+
+  it("extracts entries and verifies npm integrity metadata", () => {
+    const { tarball, metadata } = fixture();
+    expect(
+      JSON.parse(extractTarEntry(tarball, "package/package.json").toString()),
+    ).toMatchObject({ name: "@fastnear/x402", version });
+    expect(() =>
+      assertTarballIntegrity(
+        tarball,
+        metadata.dist.integrity,
+        metadata.dist.shasum,
+      )
+    ).not.toThrow();
+    expect(() =>
+      assertTarballIntegrity(tarball, "sha512-bad", metadata.dist.shasum)
+    ).toThrow("dist.integrity");
+  });
+
+  it("compares the exact jsDelivr IIFE with the verified npm tarball", async () => {
+    const { tarball, tarballUrl, metadata } = fixture();
+    const urls = [];
+    const fetchMock = async (url) => {
+      urls.push(url);
+      if (url.includes("registry.npmjs.org/@fastnear%2Fx402/")) {
+        return new Response(JSON.stringify(metadata));
+      }
+      if (url === tarballUrl) return new Response(tarball);
+      if (url.includes("cdn.jsdelivr.net/")) return new Response(iife);
+      return new Response("missing", { status: 404 });
+    };
+
+    const result = await verifyPublishedX402(version, fetchMock);
+    expect(result).toMatchObject({ version, tarballUrl, iifeBytes: iife.length });
+    expect(urls).toHaveLength(3);
+    expect(urls[0]).toContain(version);
+    expect(urls[2]).toContain(`@fastnear/x402@${version}/`);
+  });
+
+  it("rejects CDN bytes that differ from npm", async () => {
+    const { tarball, tarballUrl, metadata } = fixture();
+    const fetchMock = async (url) => {
+      if (url.includes("registry.npmjs.org/@fastnear%2Fx402/")) {
+        return new Response(JSON.stringify(metadata));
+      }
+      if (url === tarballUrl) return new Response(tarball);
+      return new Response(`${iife}\n// drift`);
+    };
+
+    await expect(verifyPublishedX402(version, fetchMock)).rejects.toThrow(
+      "jsDelivr IIFE bytes differ",
+    );
+  });
+});

--- a/scripts/smoke-agent-snippets.mjs
+++ b/scripts/smoke-agent-snippets.mjs
@@ -208,8 +208,8 @@ async function main() {
       "relatedRecipes",
     ];
 
-    if (recipeIndex.version !== 4) {
-      throw new Error(`Expected recipe catalog version 4, received ${recipeIndex.version}`);
+    if (recipeIndex.version !== 5) {
+      throw new Error(`Expected recipe catalog version 5, received ${recipeIndex.version}`);
     }
 
     if (!Array.isArray(recipeIndex.families) || recipeIndex.families.length < 6) {

--- a/scripts/smoke-package-formats.mjs
+++ b/scripts/smoke-package-formats.mjs
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises";
+import { Buffer } from "node:buffer";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -8,17 +9,87 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."
 const require = createRequire(import.meta.url);
 
 const packages = [
-  ["borsh", "NearBorsh"],
-  ["borsh-schema", "NearBorshSchema"],
-  ["utils", "NearUtils"],
-  ["api", "near"],
-  ["wallet-adapter", "nearWalletAdapters"],
-  ["wallet", "nearWallet"],
-  ["ml-dsa-65", "NearMlDsa65"],
+  { directory: "borsh", globalName: "NearBorsh" },
+  { directory: "borsh-schema", globalName: "NearBorshSchema" },
+  { directory: "utils", globalName: "NearUtils" },
+  { directory: "api", globalName: "near" },
+  { directory: "wallet-adapter", globalName: "nearWalletAdapters" },
+  { directory: "wallet", globalName: "nearWallet" },
+  { directory: "ml-dsa-65", globalName: "NearMlDsa65" },
+  {
+    directory: "x402",
+    globalName: "nearX402",
+    probes: [
+      "createFastNearWalletSigner",
+      "createNearPaymentFetch",
+      "createNearX402Client",
+    ],
+    subpaths: [
+      { exportPath: "./node", probes: ["createLocalNearSigner"] },
+      { exportPath: "./server", probes: ["createNearResourceServer"] },
+      { exportPath: "./facilitator", probes: ["createNearFacilitator"] },
+    ],
+  },
 ];
 
 function runtimeKeys(namespace) {
   return Object.keys(namespace).filter((key) => key !== "default").sort();
+}
+
+function resolveExportTarget(manifest, exportPath, condition) {
+  let target = manifest.exports?.[exportPath];
+  while (target && typeof target === "object") {
+    target = target[condition] ?? target.default;
+  }
+  if (typeof target !== "string") {
+    throw new Error(
+      `${manifest.name} is missing a ${condition} target for export ${exportPath}`,
+    );
+  }
+  return target;
+}
+
+function assertProbes(namespace, probes, label) {
+  for (const probe of probes ?? []) {
+    if (namespace[probe] === undefined) {
+      throw new Error(`${label} did not expose ${probe}`);
+    }
+  }
+}
+
+async function smokeModulePair(packageRoot, manifest, exportPath, probes) {
+  const requireTarget = exportPath === "."
+    ? manifest.main
+    : resolveExportTarget(manifest, exportPath, "require");
+  const importTarget = exportPath === "."
+    ? manifest.module
+    : resolveExportTarget(manifest, exportPath, "import");
+  const typesTarget = exportPath === "."
+    ? manifest.types
+    : resolveExportTarget(manifest, exportPath, "types");
+  const label = exportPath === "."
+    ? manifest.name
+    : `${manifest.name}/${exportPath.slice(2)}`;
+  const cjs = require(path.resolve(packageRoot, requireTarget));
+  const esm = await import(
+    `${pathToFileURL(path.resolve(packageRoot, importTarget)).href}?smoke=1`
+  );
+  await readFile(path.resolve(packageRoot, typesTarget));
+  const cjsKeys = runtimeKeys(cjs);
+  const esmKeys = runtimeKeys(esm);
+
+  if (cjsKeys.length === 0 || esmKeys.length === 0) {
+    throw new Error(`${label} exposed no runtime exports`);
+  }
+  if (JSON.stringify(cjsKeys) !== JSON.stringify(esmKeys)) {
+    throw new Error(
+      `${label} CJS/ESM export mismatch\nCJS=${JSON.stringify(cjsKeys)}\nESM=${JSON.stringify(esmKeys)}`,
+    );
+  }
+  assertProbes(cjs, probes, `${label} CJS`);
+  assertProbes(esm, probes, `${label} ESM`);
+
+  return cjsKeys.length;
 }
 
 function createBrowserSandbox() {
@@ -36,6 +107,11 @@ function createBrowserSandbox() {
     clearTimeout,
     crypto: globalThis.crypto,
     fetch: globalThis.fetch,
+    atob: globalThis.atob,
+    btoa: globalThis.btoa,
+    Headers: globalThis.Headers,
+    Request: globalThis.Request,
+    Response: globalThis.Response,
     navigator: { userAgent: "fastnear-format-smoke" },
     localStorage: {
       getItem: (key) => storage.get(key) ?? null,
@@ -50,20 +126,107 @@ function createBrowserSandbox() {
   return sandbox;
 }
 
-for (const [directory, globalName] of packages) {
+async function smokeX402BrowserPayment(sandbox) {
+  if (sandbox.Buffer !== undefined) {
+    throw new Error("x402 browser smoke must run without Node Buffer");
+  }
+  const borsh = require(path.join(repoRoot, "packages/borsh/dist/cjs/index.cjs"));
+  const { nearChainSchema } = require(
+    path.join(repoRoot, "packages/borsh-schema/dist/cjs/index.cjs"),
+  );
+  const { encodePaymentRequiredHeader } = require("@x402/core/http");
+  const requirements = {
+    scheme: "exact",
+    network: "near:testnet",
+    asset: "usdc.fakes.testnet",
+    amount: "10",
+    payTo: "seller.testnet",
+    maxTimeoutSeconds: 300,
+    extra: {},
+  };
+  const signedDelegate = Buffer.from(borsh.serialize(nearChainSchema.SignedDelegate, {
+    delegateAction: {
+      senderId: "payer.testnet",
+      receiverId: requirements.asset,
+      actions: [{
+        functionCall: {
+          methodName: "ft_transfer",
+          args: Array.from(new TextEncoder().encode(
+            '{"receiver_id":"seller.testnet","amount":"10"}',
+          )),
+          gas: 30_000_000_000_000n,
+          deposit: 1n,
+        },
+      }],
+      nonce: 1n,
+      maxBlockHeight: 1_300n,
+      publicKey: {
+        ed25519Key: {
+          data: Array.from(Buffer.from(
+            "6kpsY+KcUgq+9VB7Ey7F+ZVHdq6+vnuSQh7qaRRG0iw=",
+            "base64",
+          )),
+        },
+      },
+    },
+    signature: {
+      ed25519Signature: {
+        data: Array.from(Buffer.from(
+          "42EtRVHPX77f3XvCQD4bU00PtAAwcKPaXrLmJUG58mGZLkG7ngZ9JsXO/eYFL5ufW3agsXHfiEDjEEObnv9eBw==",
+          "base64",
+        )),
+      },
+    },
+  })).toString("base64");
+  const calls = [];
+  const fetchMock = async (...args) => {
+    calls.push(args);
+    if (calls.length === 1) {
+      return new Response(null, {
+        status: 402,
+        headers: {
+          "PAYMENT-REQUIRED": encodePaymentRequiredHeader({
+            x402Version: 2,
+            resource: { url: "https://example.test/paid" },
+            accepts: [requirements],
+          }),
+        },
+      });
+    }
+    return new Response("paid", { status: 200 });
+  };
+  const wallet = {
+    accountId: () => "payer.testnet",
+    signDelegateActions: async () => ({
+      signedDelegateActions: [{ borshSerializedBase64: signedDelegate }],
+    }),
+  };
+  const signer = sandbox.nearX402.createFastNearWalletSigner({ wallet });
+  const paidFetch = sandbox.nearX402.createNearPaymentFetch({
+    signer,
+    fetch: fetchMock,
+    network: "near:testnet",
+  });
+  const response = await paidFetch("https://example.test/paid");
+  if (await response.text() !== "paid" || calls.length !== 2) {
+    throw new Error("x402 IIFE did not complete a bufferless paid-fetch retry");
+  }
+  const retriedRequest = calls[1][0];
+  if (!(retriedRequest instanceof Request) || !retriedRequest.headers.get("PAYMENT-SIGNATURE")) {
+    throw new Error("x402 IIFE retry did not include PAYMENT-SIGNATURE");
+  }
+}
+
+for (const { directory, globalName, probes, subpaths = [] } of packages) {
   const packageRoot = path.join(repoRoot, "packages", directory);
   const manifest = JSON.parse(await readFile(path.join(packageRoot, "package.json"), "utf8"));
-  const cjs = require(path.resolve(packageRoot, manifest.main));
-  const esm = await import(`${pathToFileURL(path.resolve(packageRoot, manifest.module)).href}?smoke=1`);
-  const cjsKeys = runtimeKeys(cjs);
-  const esmKeys = runtimeKeys(esm);
-
-  if (cjsKeys.length === 0 || esmKeys.length === 0) {
-    throw new Error(`${manifest.name} exposed no runtime exports`);
-  }
-  if (JSON.stringify(cjsKeys) !== JSON.stringify(esmKeys)) {
-    throw new Error(
-      `${manifest.name} CJS/ESM export mismatch\nCJS=${JSON.stringify(cjsKeys)}\nESM=${JSON.stringify(esmKeys)}`,
+  const rootExportCount = await smokeModulePair(packageRoot, manifest, ".", probes);
+  for (const subpath of subpaths) {
+    await smokeModulePair(
+      packageRoot,
+      manifest,
+      subpath.exportPath,
+      subpath.probes,
     );
   }
 
@@ -74,6 +237,15 @@ for (const [directory, globalName] of packages) {
   if (!sandbox[globalName]) {
     throw new Error(`${manifest.name} IIFE did not expose globalThis.${globalName}`);
   }
+  assertProbes(sandbox[globalName], probes, `${manifest.name} IIFE`);
+  if (directory === "x402") {
+    await smokeX402BrowserPayment(sandbox);
+  }
 
-  console.log(`${manifest.name}: CJS, ESM, and IIFE OK (${cjsKeys.length} exports)`);
+  const subpathSummary = subpaths.length === 0
+    ? ""
+    : ` and ${subpaths.length} subpaths`;
+  console.log(
+    `${manifest.name}: CJS, ESM, and IIFE OK (${rootExportCount} root exports${subpathSummary})`,
+  );
 }

--- a/scripts/smoke-package-formats.mjs
+++ b/scripts/smoke-package-formats.mjs
@@ -239,6 +239,21 @@ for (const { directory, globalName, probes, subpaths = [] } of packages) {
   }
   assertProbes(sandbox[globalName], probes, `${manifest.name} IIFE`);
   if (directory === "x402") {
+    const descriptor = Object.getOwnPropertyDescriptor(sandbox, globalName);
+    if (!descriptor || descriptor.configurable !== false) {
+      throw new Error("@fastnear/x402 IIFE did not lock globalThis.nearX402");
+    }
+    for (const serverOnlyExport of [
+      "createLocalNearSigner",
+      "createNearResourceServer",
+      "createNearFacilitator",
+    ]) {
+      if (serverOnlyExport in sandbox[globalName]) {
+        throw new Error(
+          `@fastnear/x402 IIFE leaked server-only export ${serverOnlyExport}`,
+        );
+      }
+    }
     await smokeX402BrowserPayment(sandbox);
   }
 

--- a/scripts/smoke-packed-packages.mjs
+++ b/scripts/smoke-packed-packages.mjs
@@ -23,6 +23,7 @@ const publishPreparationScript = path.join(
 const temporaryRoot = mkdtempSync(path.join(os.tmpdir(), "fastnear-packed-smoke-"));
 const tarballsRoot = path.join(temporaryRoot, "tarballs");
 const consumerRoot = path.join(temporaryRoot, "consumer");
+const serverConsumerRoot = path.join(temporaryRoot, "x402-server-consumer");
 
 const exportProbes = {
   "@fastnear/api": ["sendTx", "queryProtocolVersion"],
@@ -297,6 +298,9 @@ function installTarballsTogether(workspaces) {
 function verifyInstalledGraph(workspaces) {
   const consumerManifest = readJson(path.join(consumerRoot, "package.json"));
   const lockfile = readJson(path.join(consumerRoot, "package-lock.json"));
+  const walletWorkspace = workspaces.find(
+    (workspace) => workspace.manifest.name === "@fastnear/wallet",
+  );
 
   for (const workspace of workspaces) {
     const { name, version } = workspace.manifest;
@@ -327,6 +331,20 @@ function verifyInstalledGraph(workspaces) {
       /^file:/,
       `${name} is not a direct local-tarball dependency`,
     );
+
+    if (name === "@fastnear/x402") {
+      assert.ok(walletWorkspace, "Missing @fastnear/wallet workspace");
+      assert.equal(
+        installedManifest.peerDependencies?.["@fastnear/wallet"],
+        walletWorkspace.manifest.version,
+        "@fastnear/x402 did not rewrite its wallet peer to the publish version",
+      );
+      assert.deepEqual(
+        installedManifest.peerDependenciesMeta?.["@fastnear/wallet"],
+        { optional: true },
+        "@fastnear/x402 must keep @fastnear/wallet optional",
+      );
+    }
 
     for (const [dependencyName, dependencyRange] of Object.entries(
       installedManifest.dependencies ?? {},
@@ -401,6 +419,73 @@ function verifyInstalledGraph(workspaces) {
   }
 }
 
+function installServerOnlyX402Consumer(workspaces) {
+  const byName = new Map(
+    workspaces.map((workspace) => [workspace.manifest.name, workspace]),
+  );
+  const x402 = byName.get("@fastnear/x402");
+  assert.ok(x402, "Missing @fastnear/x402 workspace");
+
+  const localDependencyClosure = [];
+  const visited = new Set();
+  function visit(workspace) {
+    if (visited.has(workspace.manifest.name)) return;
+    visited.add(workspace.manifest.name);
+    localDependencyClosure.push(workspace);
+    for (const dependencyName of Object.keys(workspace.manifest.dependencies ?? {})) {
+      const dependency = byName.get(dependencyName);
+      if (dependency) visit(dependency);
+    }
+  }
+  visit(x402);
+
+  assert.equal(
+    visited.has("@fastnear/wallet"),
+    false,
+    "@fastnear/x402 must not make its optional wallet peer a runtime dependency",
+  );
+
+  mkdirSync(serverConsumerRoot, { recursive: true });
+  writeFileSync(
+    path.join(serverConsumerRoot, "package.json"),
+    `${JSON.stringify({
+      name: "fastnear-x402-server-only-acceptance",
+      version: "0.0.0",
+      private: true,
+      type: "module",
+    }, null, 2)}\n`,
+  );
+
+  console.log("\nInstalling @fastnear/x402 without its optional wallet peer");
+  run(
+    "npm",
+    [
+      "install",
+      "--ignore-scripts",
+      "--no-audit",
+      "--no-fund",
+      "--prefer-offline",
+      ...localDependencyClosure.map((workspace) => workspace.tarballPath),
+    ],
+    { cwd: serverConsumerRoot },
+  );
+
+  assert.equal(
+    existsSync(path.join(serverConsumerRoot, "node_modules/@fastnear/wallet")),
+    false,
+    "A server-only @fastnear/x402 install unexpectedly installed @fastnear/wallet",
+  );
+  run(
+    process.execPath,
+    [
+      "--input-type=module",
+      "--eval",
+      'const mod = await import("@fastnear/x402/server"); if (typeof mod.createNearResourceServer !== "function") process.exit(1);',
+    ],
+    { cwd: serverConsumerRoot },
+  );
+}
+
 function smokeRuntimes() {
   const harnessPath = path.join(consumerRoot, "consume.mjs");
 
@@ -443,6 +528,7 @@ try {
   writeConsumerProject(packed);
   installTarballsTogether(packed);
   verifyInstalledGraph(packed);
+  installServerOnlyX402Consumer(packed);
   smokeRuntimes();
   assertWorkspaceManifestsUnchanged(workspaces);
   assert.equal(

--- a/scripts/smoke-packed-packages.mjs
+++ b/scripts/smoke-packed-packages.mjs
@@ -32,6 +32,19 @@ const exportProbes = {
   "@fastnear/utils": ["serializeSignedTransaction", "signerFromPrivateKey"],
   "@fastnear/wallet": ["connect", "sendTransaction"],
   "@fastnear/wallet-adapter": ["createMeteorAdapter", "createNearMobileAdapter"],
+  "@fastnear/x402": [
+    "createFastNearWalletSigner",
+    "createNearPaymentFetch",
+    "createNearX402Client",
+  ],
+};
+
+const subpathExportProbes = {
+  "@fastnear/x402": {
+    "/node": ["createLocalNearSigner"],
+    "/server": ["createNearResourceServer"],
+    "/facilitator": ["createNearFacilitator"],
+  },
 };
 
 const runtimes = [
@@ -41,6 +54,14 @@ const runtimes = [
 
 function readJson(file) {
   return JSON.parse(readFileSync(file, "utf8"));
+}
+
+function resolveExportTarget(manifest, exportPath, condition) {
+  let target = manifest.exports?.[exportPath];
+  while (target && typeof target === "object") {
+    target = target[condition] ?? target.default;
+  }
+  return typeof target === "string" ? target : undefined;
 }
 
 function run(command, args, options = {}) {
@@ -198,6 +219,7 @@ function writeConsumerProject(workspaces) {
   const packageSpecs = workspaces.map((workspace) => ({
     name: workspace.manifest.name,
     probes: exportProbes[workspace.manifest.name] ?? [],
+    subpaths: subpathExportProbes[workspace.manifest.name] ?? {},
     version: workspace.manifest.version,
   }));
 
@@ -222,22 +244,33 @@ function runtimeKeys(namespace) {
     .sort();
 }
 
-for (const packageSpec of packageSpecs) {
-  const cjs = require(packageSpec.name);
-  const esm = await import(packageSpec.name);
+async function assertModuleFormats(specifier, probes) {
+  const cjs = require(specifier);
+  const esm = await import(specifier);
   const cjsKeys = runtimeKeys(cjs);
   const esmKeys = runtimeKeys(esm);
 
-  assert.ok(cjsKeys.length > 0, packageSpec.name + " require() exposed no exports");
-  assert.ok(esmKeys.length > 0, packageSpec.name + " import exposed no exports");
-  assert.deepEqual(cjsKeys, esmKeys, packageSpec.name + " CJS/ESM export mismatch");
+  assert.ok(cjsKeys.length > 0, specifier + " require() exposed no exports");
+  assert.ok(esmKeys.length > 0, specifier + " import exposed no exports");
+  assert.deepEqual(cjsKeys, esmKeys, specifier + " CJS/ESM export mismatch");
 
-  for (const probe of packageSpec.probes) {
-    assert.notEqual(cjs[probe], undefined, packageSpec.name + " require() missed " + probe);
-    assert.notEqual(esm[probe], undefined, packageSpec.name + " import missed " + probe);
+  for (const probe of probes) {
+    assert.notEqual(cjs[probe], undefined, specifier + " require() missed " + probe);
+    assert.notEqual(esm[probe], undefined, specifier + " import missed " + probe);
+  }
+}
+
+for (const packageSpec of packageSpecs) {
+  await assertModuleFormats(packageSpec.name, packageSpec.probes);
+  for (const [subpath, probes] of Object.entries(packageSpec.subpaths)) {
+    await assertModuleFormats(packageSpec.name + subpath, probes);
   }
 
-  console.log(packageSpec.name + "@" + packageSpec.version + ": require() + import() OK");
+  const subpathCount = Object.keys(packageSpec.subpaths).length;
+  console.log(
+    packageSpec.name + "@" + packageSpec.version + ": require() + import() OK" +
+      (subpathCount === 0 ? "" : " (" + subpathCount + " subpaths)"),
+  );
 }
 
 console.log("Runtime " + process.version + ": all packed packages OK");
@@ -338,6 +371,26 @@ function verifyInstalledGraph(workspaces) {
       installedManifest.types,
     ]) {
       if (target) {
+        assert.equal(
+          existsSync(path.resolve(path.dirname(installedManifestPath), target)),
+          true,
+          `${name} tarball is missing ${target}`,
+        );
+      }
+    }
+
+    for (const subpath of Object.keys(subpathExportProbes[name] ?? {})) {
+      const exportPath = `.${subpath}`;
+      for (const condition of ["require", "import", "types"]) {
+        const target = resolveExportTarget(
+          installedManifest,
+          exportPath,
+          condition,
+        );
+        assert.ok(
+          target,
+          `${name} tarball is missing the ${condition} target for ${exportPath}`,
+        );
         assert.equal(
           existsSync(path.resolve(path.dirname(installedManifestPath), target)),
           true,

--- a/scripts/smoke-published-agent-surfaces.mjs
+++ b/scripts/smoke-published-agent-surfaces.mjs
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
@@ -9,6 +10,11 @@ const repoRoot = path.resolve(__dirname, "..");
 const localCatalog = JSON.parse(
   readFileSync(path.join(repoRoot, "recipes/index.json"), "utf8")
 );
+const localAssets = {
+  recipes: readFileSync(path.join(repoRoot, "recipes/index.json"), "utf8"),
+  llms: readFileSync(path.join(repoRoot, "llms.txt"), "utf8"),
+  llmsFull: readFileSync(path.join(repoRoot, "llms-full.txt"), "utf8"),
+};
 
 const requiredRecipeFields = [
   "service",
@@ -55,6 +61,11 @@ function assertEqualArrays(label, localValues, publicValues) {
   if (localJoined !== publicJoined) {
     throw new Error(`${label} drifted between local and public assets.\nlocal=${localJoined}\npublic=${publicJoined}`);
   }
+}
+
+function assertEqualBytes(label, localText, publicText) {
+  if (Buffer.from(localText).equals(Buffer.from(publicText))) return;
+  throw new Error(`${label} differs byte-for-byte between the generated monorepo artifact and js.fastnear.com`);
 }
 
 function inspectNearBundle(bundleSource) {
@@ -117,10 +128,18 @@ EOF`;
 }
 
 async function main() {
-  const [nearAsset, agentsAsset, recipesAsset, llmsAsset, llmsFullAsset] = await Promise.all([
+  const [
+    nearAsset,
+    agentsAsset,
+    recipesAsset,
+    generatedRecipesAsset,
+    llmsAsset,
+    llmsFullAsset,
+  ] = await Promise.all([
     fetchAsset("https://js.fastnear.com/near.js"),
     fetchAsset("https://js.fastnear.com/agents.js"),
     fetchAsset("https://js.fastnear.com/recipes.json"),
+    fetchAsset("https://js.fastnear.com/generated/recipes/index.json"),
     fetchAsset("https://js.fastnear.com/llms.txt"),
     fetchAsset("https://js.fastnear.com/llms-full.txt"),
   ]);
@@ -128,6 +147,7 @@ async function main() {
   assertNotHtmlAsset("Public near.js", nearAsset);
   assertNotHtmlAsset("Public agents.js", agentsAsset);
   assertNotHtmlAsset("Public recipes.json", recipesAsset);
+  assertNotHtmlAsset("Public generated recipes/index.json", generatedRecipesAsset);
   assertNotHtmlAsset("Public llms.txt", llmsAsset);
   assertNotHtmlAsset("Public llms-full.txt", llmsFullAsset);
 
@@ -136,6 +156,15 @@ async function main() {
   const recipesText = recipesAsset.text;
   const llmsText = llmsAsset.text;
   const llmsFullText = llmsFullAsset.text;
+
+  assertEqualBytes("Public recipes.json", localAssets.recipes, recipesText);
+  assertEqualBytes(
+    "Public generated recipes/index.json",
+    localAssets.recipes,
+    generatedRecipesAsset.text,
+  );
+  assertEqualBytes("Public llms.txt", localAssets.llms, llmsText);
+  assertEqualBytes("Public llms-full.txt", localAssets.llmsFull, llmsFullText);
 
   if (!agentsSource.includes("process.env.FASTNEAR_API_KEY") || !agentsSource.includes("globalThis.near.config({ apiKey })")) {
     throw new Error("Public agents.js is missing the FASTNEAR_API_KEY auto-config behavior");
@@ -176,6 +205,7 @@ async function main() {
   if (JSON.stringify(publicCatalog.x402) !== JSON.stringify(localCatalog.x402)) {
     throw new Error("x402 discovery metadata drifted between local and public recipes.json");
   }
+  await fetchAsset(localCatalog.x402.guideUrl);
 
   assertEqualArrays(
     "Recipe IDs",

--- a/scripts/smoke-published-agent-surfaces.mjs
+++ b/scripts/smoke-published-agent-surfaces.mjs
@@ -117,22 +117,25 @@ EOF`;
 }
 
 async function main() {
-  const [nearAsset, agentsAsset, recipesAsset, llmsAsset] = await Promise.all([
+  const [nearAsset, agentsAsset, recipesAsset, llmsAsset, llmsFullAsset] = await Promise.all([
     fetchAsset("https://js.fastnear.com/near.js"),
     fetchAsset("https://js.fastnear.com/agents.js"),
     fetchAsset("https://js.fastnear.com/recipes.json"),
     fetchAsset("https://js.fastnear.com/llms.txt"),
+    fetchAsset("https://js.fastnear.com/llms-full.txt"),
   ]);
 
   assertNotHtmlAsset("Public near.js", nearAsset);
   assertNotHtmlAsset("Public agents.js", agentsAsset);
   assertNotHtmlAsset("Public recipes.json", recipesAsset);
   assertNotHtmlAsset("Public llms.txt", llmsAsset);
+  assertNotHtmlAsset("Public llms-full.txt", llmsFullAsset);
 
   const nearSource = nearAsset.text;
   const agentsSource = agentsAsset.text;
   const recipesText = recipesAsset.text;
   const llmsText = llmsAsset.text;
+  const llmsFullText = llmsFullAsset.text;
 
   if (!agentsSource.includes("process.env.FASTNEAR_API_KEY") || !agentsSource.includes("globalThis.near.config({ apiKey })")) {
     throw new Error("Public agents.js is missing the FASTNEAR_API_KEY auto-config behavior");
@@ -140,6 +143,11 @@ async function main() {
 
   if (!llmsText.includes("https://js.fastnear.com/recipes.json") || !llmsText.includes("https://js.fastnear.com/agents.js")) {
     throw new Error("Public llms.txt is missing the expected hosted discovery entries");
+  }
+  for (const [label, text] of [["llms.txt", llmsText], ["llms-full.txt", llmsFullText]]) {
+    if (!text.includes("@fastnear/x402")) {
+      throw new Error(`Public ${label} is missing @fastnear/x402 discovery metadata`);
+    }
   }
 
   const publicNearBundle = inspectNearBundle(nearSource);
@@ -162,6 +170,11 @@ async function main() {
 
   if (publicCatalog.version !== localCatalog.version) {
     throw new Error(`Public recipe catalog version ${publicCatalog.version} does not match local version ${localCatalog.version}`);
+  }
+
+  assertEqualArrays("Package list", localCatalog.packages, publicCatalog.packages);
+  if (JSON.stringify(publicCatalog.x402) !== JSON.stringify(localCatalog.x402)) {
+    throw new Error("x402 discovery metadata drifted between local and public recipes.json");
   }
 
   assertEqualArrays(

--- a/scripts/smoke-x402-testnet.integration.test.mjs
+++ b/scripts/smoke-x402-testnet.integration.test.mjs
@@ -1,0 +1,278 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { decodeSignedTransaction, encodeTransaction } from "@near-js/transactions";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { binary_to_base58 } from "base58-js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runHarness } from "./smoke-x402-testnet.mjs";
+
+const PAYER_SECRET_KEY =
+  "ed25519:1GMkH3brNXiNNs1tiFZHu4yZSRrzJwxi5wB9bHFtMikjwpAW9DMZzU2Pqakc5it8X3N5vPmqdN7KF4CCUpmKhq";
+const RELAYER_SECRET_KEY =
+  "ed25519:AADF5hC4G2hkMNESSHciZowNS79kocbrrSQAkSU7fuUnbvpRJFV9zP6G9GV2vLWFJTmuEyoYSXQiuVczdB5fqU4";
+const ZERO_HASH = "11111111111111111111111111111111";
+const TOKEN_CODE_HASH = "DqWvPnmrMHuQaBnMmLbQ7a7d3i4vdenYMWGyUUFcet8Q";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function mockRpcResponse(rpc) {
+  if (rpc.method === "status") {
+    return { chain_id: "testnet", sync_info: { latest_block_height: 1_000 } };
+  }
+  if (rpc.method === "block") {
+    return { header: { height: 1_000, hash: ZERO_HASH } };
+  }
+  if (rpc.method !== "query") {
+    throw new Error(`Unexpected RPC method in check-only test: ${rpc.method}`);
+  }
+
+  if (rpc.params.request_type === "view_account") {
+    return {
+      amount: rpc.params.account_id === "relayer.testnet"
+        ? "1000000000000000000000000"
+        : "5000000000000000000000000",
+      locked: "0",
+      code_hash: rpc.params.account_id === "token.testnet"
+        ? TOKEN_CODE_HASH
+        : ZERO_HASH,
+      storage_usage: 100,
+      block_height: 1_000,
+      block_hash: ZERO_HASH,
+    };
+  }
+  if (rpc.params.request_type === "view_access_key") {
+    return {
+      nonce: rpc.params.account_id === "relayer.testnet" ? 7 : 41,
+      permission: "FullAccess",
+      block_height: 1_000,
+      block_hash: ZERO_HASH,
+    };
+  }
+  if (rpc.params.request_type === "call_function") {
+    const args = JSON.parse(Buffer.from(rpc.params.args_base64, "base64").toString("utf8"));
+    let value;
+    if (rpc.params.method_name === "ft_balance_of") {
+      value = args.account_id === "payer.testnet" ? "100" : "10";
+    } else if (rpc.params.method_name === "storage_balance_of") {
+      value = { total: "1", available: "0" };
+    } else if (rpc.params.method_name === "ft_metadata") {
+      value = { spec: "ft-1.0.0", name: "Mock", symbol: "MOCK", decimals: 6 };
+    } else {
+      throw new Error(`Unexpected view method: ${rpc.params.method_name}`);
+    }
+    return {
+      result: Array.from(Buffer.from(JSON.stringify(value))),
+      logs: [],
+      block_height: 1_000,
+      block_hash: ZERO_HASH,
+    };
+  }
+  throw new Error(`Unexpected query type: ${rpc.params.request_type}`);
+}
+
+describe("x402 guarded testnet harness", () => {
+  it("runs the complete in-process check-only topology without signing or submitting", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "fastnear-x402-check-"));
+    const payerCredential = path.join(directory, "payer.json");
+    const relayerCredential = path.join(directory, "relayer.json");
+    await Promise.all([
+      writeFile(payerCredential, JSON.stringify({
+        account_id: "payer.testnet",
+        private_key: PAYER_SECRET_KEY,
+      }), { mode: 0o600 }),
+      writeFile(relayerCredential, JSON.stringify({
+        account_id: "relayer.testnet",
+        private_key: RELAYER_SECRET_KEY,
+      }), { mode: 0o600 }),
+    ]);
+
+    const originalFetch = globalThis.fetch;
+    const rpcMethods = [];
+    globalThis.fetch = vi.fn(async (input, init) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url === "https://rpc.mock.test/") {
+        const rpc = JSON.parse(String(init?.body));
+        rpcMethods.push(rpc.method);
+        const result = mockRpcResponse(rpc);
+        return new Response(JSON.stringify({ jsonrpc: "2.0", id: rpc.id, result }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return originalFetch(input, init);
+    });
+    const logs = [];
+    vi.spyOn(console, "log").mockImplementation(message => logs.push(String(message)));
+
+    try {
+      await runHarness([
+        "--check-only",
+        "--payer", "payer.testnet",
+        "--payer-credential", payerCredential,
+        "--relayer", "relayer.testnet",
+        "--relayer-credential", relayerCredential,
+        "--pay-to", "merchant.testnet",
+        "--asset", "token.testnet",
+        "--amount", "1",
+        "--rpc-url", "https://rpc.mock.test/",
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      await rm(directory, { recursive: true, force: true });
+    }
+
+    expect(rpcMethods).toContain("status");
+    expect(rpcMethods).not.toContain("send_tx");
+    expect(logs).toContain(
+      "Check-only PASS: in-process facilitator support and the 402 challenge are wired",
+    );
+    expect(logs).toContain("No payment was signed and no transaction was submitted");
+  });
+
+  it("runs one paid retry through the firewall and reconciles final state", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "fastnear-x402-execute-"));
+    const payerCredential = path.join(directory, "payer.json");
+    const relayerCredential = path.join(directory, "relayer.json");
+    await Promise.all([
+      writeFile(payerCredential, JSON.stringify({
+        account_id: "payer.testnet",
+        private_key: PAYER_SECRET_KEY,
+      }), { mode: 0o600 }),
+      writeFile(relayerCredential, JSON.stringify({
+        account_id: "relayer.testnet",
+        private_key: RELAYER_SECRET_KEY,
+      }), { mode: 0o600 }),
+    ]);
+
+    const state = {
+      payerNonce: 41,
+      relayerNonce: 7,
+      payerToken: 100n,
+      recipientToken: 10n,
+      payerNear: 5_000_000_000_000_000_000_000_000n,
+      relayerNear: 1_000_000_000_000_000_000_000_000n,
+      sendCount: 0,
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (input, init) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url !== "https://rpc.mock.test/") return originalFetch(input, init);
+
+      const rpc = JSON.parse(String(init?.body));
+      let result;
+      if (rpc.method === "status") {
+        result = { chain_id: "testnet" };
+      } else if (rpc.method === "block") {
+        result = { header: { height: 1_000, hash: ZERO_HASH } };
+      } else if (rpc.method === "send_tx") {
+        state.sendCount += 1;
+        const signed = decodeSignedTransaction(
+          Buffer.from(rpc.params.signed_tx_base64, "base64"),
+        );
+        const transactionHash = binary_to_base58(
+          sha256(encodeTransaction(signed.transaction)),
+        );
+        state.payerNonce += 1;
+        state.relayerNonce += 1;
+        state.payerToken -= 1n;
+        state.recipientToken += 1n;
+        state.relayerNear -= 100_000_000_000_000_000_000n;
+        result = {
+          status: { SuccessValue: "" },
+          transaction_outcome: { id: transactionHash },
+          receipts_outcome: [{
+            outcome: {
+              executor_id: "token.testnet",
+              status: { SuccessValue: "" },
+            },
+          }],
+        };
+      } else if (rpc.method === "query" && rpc.params.request_type === "view_account") {
+        const accountId = rpc.params.account_id;
+        result = {
+          amount: accountId === "payer.testnet"
+            ? state.payerNear.toString()
+            : accountId === "relayer.testnet"
+              ? state.relayerNear.toString()
+              : "5000000000000000000000000",
+          locked: "0",
+          code_hash: accountId === "token.testnet" ? TOKEN_CODE_HASH : ZERO_HASH,
+          storage_usage: 100,
+          block_height: 1_000,
+          block_hash: ZERO_HASH,
+        };
+      } else if (rpc.method === "query" && rpc.params.request_type === "view_access_key") {
+        result = {
+          nonce: rpc.params.account_id === "relayer.testnet"
+            ? state.relayerNonce
+            : state.payerNonce,
+          permission: "FullAccess",
+          block_height: 1_000,
+          block_hash: ZERO_HASH,
+        };
+      } else if (rpc.method === "query" && rpc.params.request_type === "call_function") {
+        const args = JSON.parse(Buffer.from(rpc.params.args_base64, "base64").toString("utf8"));
+        let value;
+        if (rpc.params.method_name === "ft_balance_of") {
+          value = args.account_id === "payer.testnet"
+            ? state.payerToken.toString()
+            : state.recipientToken.toString();
+        } else if (rpc.params.method_name === "storage_balance_of") {
+          value = { total: "1", available: "0" };
+        } else if (rpc.params.method_name === "ft_metadata") {
+          value = { spec: "ft-1.0.0", name: "Mock", symbol: "MOCK", decimals: 6 };
+        } else {
+          throw new Error(`Unexpected view method: ${rpc.params.method_name}`);
+        }
+        result = {
+          result: Array.from(Buffer.from(JSON.stringify(value))),
+          logs: [],
+          block_height: 1_000,
+          block_hash: ZERO_HASH,
+        };
+      } else {
+        throw new Error(`Unexpected RPC request: ${rpc.method}`);
+      }
+      return new Response(JSON.stringify({ jsonrpc: "2.0", id: rpc.id, result }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const logs = [];
+    vi.spyOn(console, "log").mockImplementation(message => logs.push(String(message)));
+
+    try {
+      await runHarness([
+        "--execute",
+        "--payer", "payer.testnet",
+        "--payer-credential", payerCredential,
+        "--relayer", "relayer.testnet",
+        "--relayer-credential", relayerCredential,
+        "--pay-to", "merchant.testnet",
+        "--asset", "token.testnet",
+        "--amount", "1",
+        "--rpc-url", "https://rpc.mock.test/",
+        "--confirm-network", "testnet",
+        "--confirm-payer", "payer.testnet",
+        "--confirm-pay-to", "merchant.testnet",
+        "--confirm-relayer", "relayer.testnet",
+        "--confirm-asset", "token.testnet",
+        "--confirm-amount", "1",
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      await rm(directory, { recursive: true, force: true });
+    }
+
+    expect(state.sendCount).toBe(1);
+    expect(state.payerToken).toBe(99n);
+    expect(state.recipientToken).toBe(11n);
+    expect(logs.some(message => message.startsWith("Settlement PASS: "))).toBe(true);
+    expect(logs).toContain(
+      "Reconciliation PASS: exact token deltas, sponsored costs, both nonces, and replay rejection",
+    );
+  });
+});

--- a/scripts/smoke-x402-testnet.mjs
+++ b/scripts/smoke-x402-testnet.mjs
@@ -1,0 +1,1376 @@
+import { constants, open, readFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { signerFromPrivateKey } from "@fastnear/utils";
+import { createNearPaymentFetch } from "@fastnear/x402";
+import { createNearFacilitator } from "@fastnear/x402/facilitator";
+import { createLocalNearSigner } from "@fastnear/x402/node";
+import { createNearResourceServer } from "@fastnear/x402/server";
+import {
+  decodePaymentRequiredHeader,
+  decodePaymentResponseHeader,
+  decodePaymentSignatureHeader,
+  encodePaymentRequiredHeader,
+  encodePaymentResponseHeader,
+} from "@x402/core/http";
+import {
+  SettlementCache,
+  decodeSignedDelegateB64,
+  parseFtTransferArgs,
+} from "@x402/near";
+import {
+  decodeSignedTransaction,
+  encodeSignedDelegate,
+  encodeTransaction,
+} from "@near-js/transactions";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { binary_to_base58 } from "base58-js";
+import {
+  MAX_TIMEOUT_SECONDS,
+  credentialMetadataError,
+  normalizeHarnessOptions,
+  parseHarnessArgs,
+  sanitizedRpcUrl,
+  transformWalletSmokePage,
+} from "./x402-testnet-helpers.mjs";
+
+const NETWORK = "near:testnet";
+const CHAIN_ID = "testnet";
+const ZERO_CODE_HASH = "11111111111111111111111111111111";
+const FT_TRANSFER_GAS = 30_000_000_000_000n;
+const ONE_YOCTO = 1n;
+const MIN_RELAYER_BALANCE = 100_000_000_000_000_000_000_000n;
+const MAX_BODY_BYTES = 64 * 1024;
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const HELP = `Usage:
+  yarn smoke:x402:testnet -- --check-only [fixture options]
+  yarn smoke:x402:testnet -- --execute [fixture options] [confirmations]
+  yarn smoke:x402:testnet -- --serve-wallet [fixture options] [confirmations]
+
+Modes:
+  --check-only       Read-only testnet, credential, HTTP, and package preflight (default)
+  --execute          Make one local-key payment and reconcile it at finality
+  --serve-wallet     Serve a one-payment-only browser QA page on 127.0.0.1
+
+Required fixture options:
+  --payer <account.testnet>
+  --payer-credential <file>       Required for check/execute; forbidden for wallet mode
+  --relayer <account.testnet>
+  --relayer-credential <file>
+  --pay-to <account.testnet>
+  --asset <token.testnet|64-char implicit account>
+  --amount <atomic units>         Positive integer, capped at 1000000
+  --rpc-url <https URL>
+
+State-changing confirmations:
+  --confirm-network testnet
+  --confirm-payer <exact payer>
+  --confirm-pay-to <exact recipient>
+  --confirm-relayer <exact relayer>
+  --confirm-asset <exact token>
+  --confirm-amount <exact atomic amount>
+
+Wallet-only options:
+  --port <0-65535>                Defaults to an ephemeral loopback port
+  --expected-wallet <exact name>  Must match nearWallet.walletName()
+  --bundle-version <exact semver>  Load immutable npm bundles instead of local builds
+  --wallet-manifest <https URL>   Optional candidate/custom near-connect manifest
+  --wallet-timeout-seconds <n>    1-3600 seconds; defaults to 900
+
+No payment is signed or submitted unless --execute is present or a user clicks
+Pay in --serve-wallet mode. Credential files must be owner-only (chmod 600 or 400).`;
+
+let nextRpcId = 1;
+
+function invariant(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function shellArg(value) {
+  return `'${String(value).replaceAll("'", `'"'"'`)}'`;
+}
+
+function safeErrorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function sanitizedErrorMessage(error, rpcUrl) {
+  let message = safeErrorMessage(error);
+  if (rpcUrl) {
+    message = message.replaceAll(rpcUrl.href, sanitizedRpcUrl(rpcUrl));
+    if (rpcUrl.search) message = message.replaceAll(rpcUrl.search, "");
+  }
+  return message;
+}
+
+function createDeferred() {
+  let resolve;
+  const promise = new Promise(innerResolve => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
+class RpcResponseError extends Error {
+  constructor(method, rpcError) {
+    const detail = typeof rpcError?.message === "string"
+      ? rpcError.message.slice(0, 300)
+      : "unknown RPC error";
+    super(`RPC ${method} failed: ${detail}`);
+    this.rpcError = rpcError;
+  }
+}
+
+class HttpInputError extends Error {
+  constructor(status, message) {
+    super(message);
+    this.status = status;
+  }
+}
+
+function jsonStringify(value) {
+  return JSON.stringify(value, (_, item) => typeof item === "bigint" ? item.toString() : item);
+}
+
+function sendJson(response, status, value, extraHeaders = {}) {
+  const body = jsonStringify(value);
+  response.writeHead(status, {
+    "cache-control": "no-store",
+    "content-type": "application/json; charset=utf-8",
+    "content-length": Buffer.byteLength(body),
+    "x-content-type-options": "nosniff",
+    ...extraHeaders,
+  });
+  response.end(body);
+}
+
+function sendBytes(response, contentType, bytes) {
+  response.writeHead(200, {
+    "cache-control": "no-store",
+    "content-type": contentType,
+    "content-length": bytes.length,
+    "x-content-type-options": "nosniff",
+  });
+  response.end(bytes);
+}
+
+async function readRequestBody(request, limit = MAX_BODY_BYTES) {
+  const declared = Number(request.headers["content-length"] ?? 0);
+  if (Number.isFinite(declared) && declared > limit) {
+    throw new HttpInputError(413, "Request body is too large");
+  }
+
+  const chunks = [];
+  let size = 0;
+  for await (const chunk of request) {
+    const bytes = Buffer.from(chunk);
+    size += bytes.length;
+    if (size > limit) throw new HttpInputError(413, "Request body is too large");
+    chunks.push(bytes);
+  }
+  return Buffer.concat(chunks);
+}
+
+async function readJsonRequest(request) {
+  const contentType = request.headers["content-type"] ?? "";
+  if (!contentType.toLowerCase().startsWith("application/json")) {
+    throw new HttpInputError(415, "Content-Type must be application/json");
+  }
+  const bytes = await readRequestBody(request);
+  try {
+    return JSON.parse(bytes.toString("utf8"));
+  } catch {
+    throw new HttpInputError(400, "Request body must be valid JSON");
+  }
+}
+
+function configureServer(server, requestTimeout = 120_000) {
+  server.headersTimeout = 10_000;
+  server.requestTimeout = requestTimeout;
+  server.keepAliveTimeout = 1_000;
+  server.setTimeout(requestTimeout);
+  return server;
+}
+
+async function listenLoopback(server, port = 0) {
+  await new Promise((resolve, reject) => {
+    const onError = error => {
+      server.removeListener("listening", onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.removeListener("error", onError);
+      resolve();
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(port, "127.0.0.1");
+  });
+  const address = server.address();
+  invariant(address && typeof address === "object", "Loopback server did not expose an address");
+  return {
+    port: address.port,
+    host: `127.0.0.1:${address.port}`,
+    url: `http://127.0.0.1:${address.port}`,
+  };
+}
+
+async function closeServer(server) {
+  if (!server?.listening) return;
+  server.closeIdleConnections?.();
+  await new Promise(resolve => {
+    let finished = false;
+    const finish = () => {
+      if (finished) return;
+      finished = true;
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      server.closeAllConnections?.();
+      finish();
+    }, 1_000);
+    server.close(finish);
+  });
+}
+
+function validHost(request, expectedHost) {
+  return request.headers.host === expectedHost;
+}
+
+async function callRpc(rpcUrl, method, params) {
+  const response = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: nextRpcId++, method, params }),
+    signal: AbortSignal.timeout(120_000),
+  });
+  if (!response.ok) throw new Error(`Local RPC proxy returned HTTP ${response.status}`);
+  const body = await response.json();
+  if (body.error) throw new RpcResponseError(method, body.error);
+  return body.result;
+}
+
+function decodeAndAssertDelegate(encoded, expected) {
+  let decoded;
+  try {
+    decoded = decodeSignedDelegateB64(encoded);
+  } catch {
+    throw new Error("Payment contains a malformed signed delegate action");
+  }
+  invariant(decoded.verifySignature(), "Signed delegate signature is invalid");
+  const { delegate } = decoded;
+  invariant(delegate.senderId === expected.payer, "Signed delegate payer does not match the fixture");
+  invariant(delegate.receiverId === expected.asset, "Signed delegate token does not match the fixture");
+  if (expected.publicKey) {
+    invariant(delegate.publicKey === expected.publicKey, "Signed delegate key does not match the payer credential");
+  }
+  invariant(delegate.actionCount === 1, "Signed delegate must contain exactly one action");
+  invariant(delegate.functionCall, "Signed delegate action is not a function call");
+  invariant(delegate.functionCall.methodName === "ft_transfer", "Signed delegate method is not ft_transfer");
+  invariant(delegate.functionCall.gas === FT_TRANSFER_GAS, "Signed delegate gas is not 30 TGas");
+  invariant(delegate.functionCall.deposit === ONE_YOCTO, "Signed delegate deposit is not 1 yoctoNEAR");
+
+  let rawArguments;
+  try {
+    rawArguments = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(
+      delegate.functionCall.args,
+    ));
+  } catch {
+    throw new Error("Signed delegate has malformed ft_transfer arguments");
+  }
+  const transfer = parseFtTransferArgs(delegate.functionCall.args);
+  invariant(
+    Object.keys(rawArguments).sort().join(",") === "amount,receiver_id",
+    "Signed delegate contains unexpected ft_transfer arguments",
+  );
+  invariant(transfer.receiver_id === expected.payTo, "Signed delegate recipient does not match the fixture");
+  invariant(transfer.amount === expected.amountText, "Signed delegate amount does not match the fixture");
+  if (expected.nonce !== undefined) {
+    invariant(delegate.nonce === expected.nonce, "Signed delegate nonce is not the expected access-key nonce");
+  }
+  if (expected.maxBlockHeight !== undefined) {
+    invariant(
+      delegate.maxBlockHeight === expected.maxBlockHeight,
+      "Signed delegate maximum height does not equal final height plus timeout",
+    );
+  }
+  return decoded;
+}
+
+function decodedPublicKeyString(publicKey) {
+  const ed25519 = publicKey?.ed25519Key?.data;
+  if (ed25519) return `ed25519:${binary_to_base58(Uint8Array.from(ed25519))}`;
+  const secp256k1 = publicKey?.secp256k1Key?.data;
+  if (secp256k1) return `secp256k1:${binary_to_base58(Uint8Array.from(secp256k1))}`;
+  throw new Error("Outer transaction contains an unsupported public key");
+}
+
+function inspectOuterSubmission(params, expected) {
+  invariant(params && typeof params === "object", "send_tx params must be an object");
+  invariant(params.wait_until === "FINAL", "Settlement must use wait_until FINAL");
+  invariant(typeof params.signed_tx_base64 === "string", "send_tx is missing signed_tx_base64");
+
+  let decoded;
+  try {
+    decoded = decodeSignedTransaction(Buffer.from(params.signed_tx_base64, "base64"));
+  } catch {
+    throw new Error("Settlement contains a malformed outer transaction");
+  }
+  const { transaction } = decoded;
+  invariant(transaction.signerId === expected.relayer, "Outer transaction signer is not the configured relayer");
+  invariant(transaction.receiverId === expected.payer, "Outer transaction receiver is not the configured payer");
+  if (expected.relayerPublicKey) {
+    invariant(
+      decodedPublicKeyString(transaction.publicKey) === expected.relayerPublicKey,
+      "Outer transaction key is not the configured relayer key",
+    );
+  }
+  invariant(transaction.actions.length === 1, "Outer transaction must contain one action");
+  const signedDelegate = transaction.actions[0].signedDelegate;
+  invariant(signedDelegate, "Outer transaction action is not a signed delegate");
+  const encodedDelegate = Buffer.from(encodeSignedDelegate(signedDelegate)).toString("base64");
+  const delegate = decodeAndAssertDelegate(encodedDelegate, expected);
+  const transactionHash = binary_to_base58(
+    sha256(encodeTransaction(transaction)),
+  );
+
+  return { decoded, delegate, encodedDelegate, transactionHash };
+}
+
+function mutationMethod(method) {
+  return method === "send_tx" ||
+    method === "broadcast_tx_async" ||
+    method === "broadcast_tx_commit" ||
+    method === "EXPERIMENTAL_send_tx";
+}
+
+function latestAccessKeyNonce(records, accountId, publicKey) {
+  const record = records.findLast(item =>
+    item.request?.method === "query" &&
+    item.request?.params?.request_type === "view_access_key" &&
+    item.request?.params?.account_id === accountId &&
+    item.request?.params?.public_key === publicKey &&
+    item.response?.result?.nonce !== undefined
+  );
+  invariant(record, `No final access-key read was observed for ${accountId}`);
+  return BigInt(record.response.result.nonce);
+}
+
+function observedBlockHeights(records) {
+  return records.flatMap(record =>
+    record.request?.method === "block" && record.response?.result?.header?.height !== undefined
+      ? [BigInt(record.response.result.header.height)]
+      : []
+  );
+}
+
+async function startRpcProxy(upstreamUrl, allowTransactions, expected) {
+  const records = [];
+  const submissions = [];
+  const errors = [];
+  let endpoint;
+
+  const server = configureServer(createServer(async (request, response) => {
+    let rpc;
+    try {
+      if (!endpoint || !validHost(request, endpoint.host)) {
+        sendJson(response, 421, { error: "Misdirected request" });
+        return;
+      }
+      if (request.method !== "POST" || request.url !== "/") {
+        sendJson(response, 404, { error: "Not found" });
+        return;
+      }
+      rpc = await readJsonRequest(request);
+      if (!rpc || typeof rpc !== "object" || Array.isArray(rpc) || typeof rpc.method !== "string") {
+        throw new HttpInputError(400, "A single JSON-RPC request is required");
+      }
+
+      if (mutationMethod(rpc.method)) {
+        if (!allowTransactions) {
+          sendJson(response, 200, {
+            jsonrpc: "2.0",
+            id: rpc.id,
+            error: { code: -32000, message: "Transactions are disabled in check-only mode" },
+          });
+          return;
+        }
+        if (rpc.method !== "send_tx") {
+          throw new HttpInputError(403, `Mutation method ${rpc.method} is not permitted`);
+        }
+        if (submissions.length >= 1) {
+          throw new HttpInputError(403, "This harness permits only one transaction submission");
+        }
+        const inspection = inspectOuterSubmission(rpc.params, expected);
+        const payerNonce = latestAccessKeyNonce(
+          records,
+          expected.payer,
+          inspection.delegate.delegate.publicKey,
+        );
+        invariant(
+          inspection.delegate.delegate.nonce === payerNonce + 1n,
+          "RPC firewall rejected a delegate nonce that was not the final access-key nonce plus one",
+        );
+        const relayerNonce = latestAccessKeyNonce(
+          records,
+          expected.relayer,
+          expected.relayerPublicKey,
+        );
+        invariant(
+          inspection.decoded.transaction.nonce === relayerNonce + 1n,
+          "RPC firewall rejected an outer nonce that was not the final relayer nonce plus one",
+        );
+
+        const heights = observedBlockHeights(records);
+        invariant(heights.length > 0, "RPC firewall did not observe a final block height");
+        if (expected.mode === "execute") {
+          invariant(
+            inspection.delegate.delegate.maxBlockHeight ===
+              heights[0] + BigInt(MAX_TIMEOUT_SECONDS),
+            "RPC firewall rejected a local delegate with the wrong timeout height",
+          );
+        } else {
+          const currentHeight = heights[heights.length - 1];
+          invariant(
+            inspection.delegate.delegate.maxBlockHeight > currentHeight &&
+              inspection.delegate.delegate.maxBlockHeight <=
+                currentHeight + BigInt(MAX_TIMEOUT_SECONDS),
+            "RPC firewall rejected a wallet delegate outside the configured timeout window",
+          );
+        }
+        submissions.push({ request: rpc, response: undefined, ...inspection });
+      }
+
+      const record = { request: rpc, response: undefined };
+      records.push(record);
+      const upstreamResponse = await fetch(upstreamUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(rpc),
+        redirect: "error",
+        signal: AbortSignal.timeout(120_000),
+      });
+      const bytes = Buffer.from(await upstreamResponse.arrayBuffer());
+      let parsedResponse;
+      try {
+        parsedResponse = JSON.parse(bytes.toString("utf8"));
+      } catch {
+        throw new Error("Upstream RPC returned malformed JSON");
+      }
+      record.response = parsedResponse;
+      if (rpc.method === "send_tx" && submissions.length > 0) {
+        submissions[submissions.length - 1].response = parsedResponse;
+      }
+      response.writeHead(upstreamResponse.status, {
+        "cache-control": "no-store",
+        "content-type": "application/json; charset=utf-8",
+        "content-length": bytes.length,
+        "x-content-type-options": "nosniff",
+      });
+      response.end(bytes);
+    } catch (error) {
+      errors.push(error);
+      const status = error instanceof HttpInputError ? error.status : 502;
+      sendJson(response, status, {
+        jsonrpc: "2.0",
+        id: rpc?.id ?? null,
+        error: {
+          code: status === 502 ? -32001 : -32600,
+          message: status === 502 ? "RPC proxy transport failed" : safeErrorMessage(error),
+        },
+      });
+    }
+  }), 120_000);
+
+  endpoint = await listenLoopback(server);
+  return {
+    ...endpoint,
+    server,
+    records,
+    submissions,
+    errors,
+    resetRecords() {
+      records.length = 0;
+    },
+  };
+}
+
+async function loadCredential(accountId, filename) {
+  let handle;
+  try {
+    handle = await open(filename, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+  } catch (error) {
+    if (error?.code === "ELOOP") {
+      throw new Error(`Credential path must not be a symbolic link: ${filename}`);
+    }
+    throw new Error(`Could not open credential file: ${filename}`);
+  }
+
+  try {
+    const metadata = await handle.stat();
+    const metadataError = credentialMetadataError(
+      metadata,
+      typeof process.getuid === "function" ? process.getuid() : undefined,
+    );
+    if (metadataError) {
+      const fix = metadataError.startsWith("Credential permissions")
+        ? `; run chmod 600 ${shellArg(filename)}`
+        : "";
+      throw new Error(`${metadataError}: ${filename}${fix}`);
+    }
+
+    let credential;
+    try {
+      credential = JSON.parse(await handle.readFile("utf8"));
+    } catch {
+      throw new Error(`Credential file is not valid JSON: ${filename}`);
+    }
+    if (!credential || typeof credential !== "object" || Array.isArray(credential)) {
+      throw new Error(`Credential file must contain an object: ${filename}`);
+    }
+    if (credential.account_id !== accountId) {
+      throw new Error(`Credential account does not exactly match ${accountId}: ${filename}`);
+    }
+    if (
+      credential.private_key !== undefined &&
+      credential.secret_key !== undefined &&
+      credential.private_key !== credential.secret_key
+    ) {
+      throw new Error(`Credential has conflicting private_key and secret_key values: ${filename}`);
+    }
+    const secretKey = credential.private_key ?? credential.secret_key;
+    if (typeof secretKey !== "string") {
+      throw new Error(`Credential is missing private_key/secret_key: ${filename}`);
+    }
+
+    let signer;
+    try {
+      signer = signerFromPrivateKey(secretKey);
+    } catch {
+      throw new Error(`Credential contains an invalid private key: ${filename}`);
+    }
+    if (credential.public_key !== undefined && credential.public_key !== signer.publicKey) {
+      throw new Error(`Credential public_key does not match its private key: ${filename}`);
+    }
+    return { accountId, filename, publicKey: signer.publicKey, secretKey };
+  } finally {
+    await handle.close();
+  }
+}
+
+async function loadCredentials(options) {
+  const specifications = [
+    { role: "relayer", accountId: options.relayer, filename: options.relayerCredential },
+  ];
+  if (options.payerCredential) {
+    specifications.unshift({
+      role: "payer",
+      accountId: options.payer,
+      filename: options.payerCredential,
+    });
+  }
+
+  const results = await Promise.allSettled(
+    specifications.map(specification => loadCredential(
+      specification.accountId,
+      specification.filename,
+    )),
+  );
+  const failures = results.flatMap((result, index) => result.status === "rejected"
+    ? [`${specifications[index].role}: ${safeErrorMessage(result.reason)}`]
+    : []);
+  if (failures.length > 0) {
+    for (const result of results) {
+      if (result.status === "fulfilled") result.value.secretKey = "";
+    }
+    throw new Error(`Credential preflight failed:\n- ${failures.join("\n- ")}`);
+  }
+
+  const loaded = Object.fromEntries(results.map((result, index) => [
+    specifications[index].role,
+    result.value,
+  ]));
+  if (loaded.payer && loaded.payer.publicKey === loaded.relayer.publicKey) {
+    throw new Error("Payer and relayer credentials must not use the same public key");
+  }
+  return loaded;
+}
+
+function base64Json(value) {
+  return Buffer.from(JSON.stringify(value)).toString("base64");
+}
+
+async function queryFinal(rpcUrl, blockHash, request) {
+  return callRpc(rpcUrl, "query", { ...request, block_id: blockHash });
+}
+
+async function viewAccount(rpcUrl, blockHash, accountId) {
+  return queryFinal(rpcUrl, blockHash, {
+    request_type: "view_account",
+    account_id: accountId,
+  });
+}
+
+async function viewAccessKey(rpcUrl, blockHash, accountId, publicKey) {
+  return queryFinal(rpcUrl, blockHash, {
+    request_type: "view_access_key",
+    account_id: accountId,
+    public_key: publicKey,
+  });
+}
+
+async function callFunction(rpcUrl, blockHash, contractId, methodName, args) {
+  const result = await queryFinal(rpcUrl, blockHash, {
+    request_type: "call_function",
+    account_id: contractId,
+    method_name: methodName,
+    args_base64: base64Json(args),
+  });
+  if (typeof result?.error === "string") {
+    throw new Error(result.error);
+  }
+  try {
+    return JSON.parse(Buffer.from(result.result).toString("utf8"));
+  } catch {
+    throw new Error(`${contractId}.${methodName} returned malformed JSON`);
+  }
+}
+
+async function ftBalanceOf(rpcUrl, blockHash, token, accountId) {
+  const value = await callFunction(rpcUrl, blockHash, token, "ft_balance_of", {
+    account_id: accountId,
+  });
+  if (typeof value !== "string" || !/^[0-9]+$/.test(value)) {
+    throw new Error(`${token}.ft_balance_of returned a non-integer balance`);
+  }
+  return BigInt(value);
+}
+
+function methodMissing(error) {
+  const detail = error instanceof RpcResponseError
+    ? `${error.message} ${jsonStringify(error.rpcError)}`
+    : safeErrorMessage(error);
+  return /MethodNotFound|MethodResolveError|MethodEmptyName/i.test(detail);
+}
+
+async function collectChainSnapshot(rpcUrl, options, payerPublicKey, relayerPublicKey) {
+  const block = await callRpc(rpcUrl, "block", { finality: "final" });
+  const blockHash = block?.header?.hash;
+  invariant(typeof blockHash === "string", "Final block response is missing its hash");
+  const blockHeight = BigInt(block.header.height);
+
+  const [payerAccount, payToAccount, relayerAccount, tokenAccount] = await Promise.all([
+    viewAccount(rpcUrl, blockHash, options.payer),
+    viewAccount(rpcUrl, blockHash, options.payTo),
+    viewAccount(rpcUrl, blockHash, options.relayer),
+    viewAccount(rpcUrl, blockHash, options.asset),
+  ]);
+  const [payerToken, payToToken, payerKey, relayerKey] = await Promise.all([
+    ftBalanceOf(rpcUrl, blockHash, options.asset, options.payer),
+    ftBalanceOf(rpcUrl, blockHash, options.asset, options.payTo),
+    payerPublicKey
+      ? viewAccessKey(rpcUrl, blockHash, options.payer, payerPublicKey)
+      : Promise.resolve(undefined),
+    viewAccessKey(rpcUrl, blockHash, options.relayer, relayerPublicKey),
+  ]);
+
+  return {
+    blockHash,
+    blockHeight,
+    payerAccount,
+    payToAccount,
+    relayerAccount,
+    tokenAccount,
+    payerToken,
+    payToToken,
+    payerKey,
+    relayerKey,
+  };
+}
+
+async function runPreflight(rpcUrl, options, credentials) {
+  const status = await callRpc(rpcUrl, "status", []);
+  invariant(status?.chain_id === CHAIN_ID, `RPC chain_id must be ${CHAIN_ID}`);
+  const snapshot = await collectChainSnapshot(
+    rpcUrl,
+    options,
+    credentials.payer?.publicKey,
+    credentials.relayer.publicKey,
+  );
+
+  invariant(snapshot.tokenAccount.code_hash !== ZERO_CODE_HASH, "Configured token account has no contract code");
+  invariant(snapshot.payerToken >= options.amount, "Payer token balance is below the configured amount");
+  invariant(
+    BigInt(snapshot.relayerAccount.amount) >= MIN_RELAYER_BALANCE,
+    "Relayer has less than 0.1 testnet NEAR available",
+  );
+  if (snapshot.payerKey) {
+    invariant(snapshot.payerKey.permission === "FullAccess", "Payer credential is not an on-chain FullAccess key");
+  }
+  invariant(snapshot.relayerKey.permission === "FullAccess", "Relayer credential is not an on-chain FullAccess key");
+
+  let storage;
+  try {
+    storage = await callFunction(
+      rpcUrl,
+      snapshot.blockHash,
+      options.asset,
+      "storage_balance_of",
+      { account_id: options.payTo },
+    );
+    invariant(storage !== null, "Recipient is not registered for storage with the token");
+  } catch (error) {
+    if (!methodMissing(error)) throw error;
+    storage = undefined;
+  }
+
+  let metadata;
+  try {
+    metadata = await callFunction(rpcUrl, snapshot.blockHash, options.asset, "ft_metadata", {});
+  } catch (error) {
+    if (!methodMissing(error)) throw error;
+  }
+
+  console.log(`RPC lock: ${sanitizedRpcUrl(options.rpcUrl)} -> testnet at final height ${snapshot.blockHeight}`);
+  console.log(`Payer: ${options.payer} (${snapshot.payerToken} atomic ${metadata?.symbol ?? options.asset})`);
+  if (credentials.payer) console.log(`Payer FullAccess key: ${credentials.payer.publicKey}`);
+  console.log(`Recipient: ${options.payTo} (${snapshot.payToToken} atomic before payment)`);
+  console.log(`Recipient storage: ${storage === undefined ? "token does not expose storage_balance_of" : "registered"}`);
+  console.log(`Relayer: ${options.relayer} (${snapshot.relayerAccount.amount} yoctoNEAR)`);
+  console.log(`Relayer FullAccess key: ${credentials.relayer.publicKey}`);
+  console.log(`Fixture: transfer ${options.amountText} atomic units of ${options.asset}`);
+  return snapshot;
+}
+
+async function loadWalletAssets(bundleVersion) {
+  const files = {
+    html: path.join(REPO_ROOT, "examples/static/x402.html"),
+    css: path.join(REPO_ROOT, "examples/static/style.css"),
+    favicon: path.join(REPO_ROOT, "examples/static/assets/favicon.ico"),
+    logo: path.join(REPO_ROOT, "examples/static/assets/fastnear_logo_black.png"),
+    wallet: path.join(REPO_ROOT, "packages/wallet/dist/umd/browser.global.js"),
+    x402: path.join(REPO_ROOT, "packages/x402/dist/umd/browser.global.js"),
+  };
+  try {
+    const [html, css, favicon, logo] = await Promise.all([
+      readFile(files.html, "utf8"),
+      readFile(files.css),
+      readFile(files.favicon),
+      readFile(files.logo),
+    ]);
+    if (bundleVersion !== undefined) {
+      return { html, css, favicon, logo };
+    }
+    const [wallet, x402] = await Promise.all([
+      readFile(files.wallet),
+      readFile(files.x402),
+    ]);
+    return { html, css, favicon, logo, wallet, x402 };
+  } catch {
+    throw new Error(
+      bundleVersion === undefined
+        ? "Wallet smoke assets are missing; run yarn build first"
+        : "Wallet smoke page assets are missing",
+    );
+  }
+}
+
+function protectedResourceInfo(url) {
+  return {
+    url,
+    description: "FastNEAR x402 testnet smoke fixture",
+    mimeType: "application/json",
+  };
+}
+
+async function startSellerServer(resourceServer, options, walletAssets, captureBaseline) {
+  const state = {
+    hits: 0,
+    closed: false,
+    payment: undefined,
+    requirements: undefined,
+    settlement: undefined,
+    settlementError: undefined,
+    requestError: undefined,
+    baselinePromise: undefined,
+    walletName: undefined,
+  };
+  const settlementSignal = createDeferred();
+  const paymentStartedSignal = createDeferred();
+  let endpoint;
+  let requirements;
+  let paymentRequired;
+  let resourceInfo;
+
+  const sendChallenge = async (response, error, paymentPayload) => {
+    const challenge = error
+      ? await resourceServer.createPaymentRequiredResponse(
+        [requirements],
+        resourceInfo,
+        error,
+        undefined,
+        undefined,
+        paymentPayload,
+      )
+      : paymentRequired;
+    sendJson(response, 402, { error: error ?? "Payment required" }, {
+      "payment-required": encodePaymentRequiredHeader(challenge),
+    });
+  };
+
+  const server = configureServer(createServer(async (request, response) => {
+    try {
+      if (!endpoint || !validHost(request, endpoint.host)) {
+        sendJson(response, 421, { error: "Misdirected request" });
+        return;
+      }
+      const url = new URL(request.url, endpoint.url);
+      if (url.search) throw new HttpInputError(400, "Query parameters are not accepted");
+
+      if (walletAssets && request.method === "GET") {
+        const staticRoutes = {
+          "/style.css": ["text/css; charset=utf-8", walletAssets.css],
+          "/assets/favicon.ico": ["image/x-icon", walletAssets.favicon],
+          "/assets/fastnear_logo_black.png": ["image/png", walletAssets.logo],
+        };
+        if (walletAssets.wallet !== undefined && walletAssets.x402 !== undefined) {
+          staticRoutes["/bundles/wallet.js"] = [
+            "text/javascript; charset=utf-8",
+            walletAssets.wallet,
+          ];
+          staticRoutes["/bundles/x402.js"] = [
+            "text/javascript; charset=utf-8",
+            walletAssets.x402,
+          ];
+        }
+        if (url.pathname === "/" || url.pathname === "/x402.html") {
+          const html = transformWalletSmokePage(walletAssets.html, {
+            network: "testnet",
+            endpoint: "/paid",
+            payer: options.payer,
+            payTo: options.payTo,
+            asset: options.asset,
+            amount: options.amountText,
+            expectedWallet: options.expectedWallet,
+            manifest: options.walletManifest,
+          }, options.bundleVersion);
+          sendBytes(response, "text/html; charset=utf-8", Buffer.from(html));
+          return;
+        }
+        if (staticRoutes[url.pathname]) {
+          sendBytes(response, ...staticRoutes[url.pathname]);
+          return;
+        }
+      }
+
+      if (url.pathname !== "/paid") {
+        sendJson(response, 404, { error: "Not found" });
+        return;
+      }
+      if (request.method !== "GET") {
+        sendJson(response, 405, { error: "Method not allowed" }, { allow: "GET" });
+        return;
+      }
+      state.hits += 1;
+      if (state.closed) {
+        sendJson(response, 409, { error: "This one-payment smoke session is closed" });
+        return;
+      }
+
+      if (walletAssets) {
+        const walletName = request.headers["x-fastnear-smoke-wallet"];
+        if (walletName !== options.expectedWallet) {
+          sendJson(response, 400, { error: "Reported wallet does not match this smoke session" });
+          return;
+        }
+        state.walletName = walletName;
+      }
+
+      state.baselinePromise ??= captureBaseline();
+      await state.baselinePromise;
+
+      const paymentHeader = request.headers["payment-signature"];
+      if (typeof paymentHeader !== "string") {
+        await sendChallenge(response);
+        return;
+      }
+
+      let paymentPayload;
+      try {
+        paymentPayload = decodePaymentSignatureHeader(paymentHeader);
+      } catch {
+        await sendChallenge(response, "Malformed payment signature");
+        return;
+      }
+      if (paymentPayload.x402Version !== 2) {
+        await sendChallenge(response, "Only x402 v2 is accepted", paymentPayload);
+        return;
+      }
+      const matched = resourceServer.findMatchingRequirements(
+        paymentRequired.accepts,
+        paymentPayload,
+      );
+      if (!matched) {
+        await sendChallenge(response, "No matching payment requirements", paymentPayload);
+        return;
+      }
+      const extensionResult = resourceServer.validateExtensions(paymentRequired, paymentPayload);
+      if (!extensionResult.valid) {
+        await sendChallenge(response, extensionResult.invalidReason, paymentPayload);
+        return;
+      }
+      const verification = await resourceServer.verifyPayment(paymentPayload, matched);
+      if (!verification.isValid || verification.payer !== options.payer) {
+        await sendChallenge(
+          response,
+          verification.payer && verification.payer !== options.payer
+            ? "Verified payer does not match this smoke session"
+            : verification.invalidReason ?? "Payment verification failed",
+          paymentPayload,
+        );
+        return;
+      }
+
+      // Verification performs RPC reads and yields to the event loop. Claim the
+      // one-shot session atomically after it returns and before settlement can
+      // yield, so concurrent paid requests cannot both reach the relayer.
+      if (state.closed) {
+        sendJson(response, 409, { error: "This one-payment smoke session is closed" });
+        return;
+      }
+      state.closed = true;
+
+      state.payment = paymentPayload;
+      state.requirements = matched;
+      paymentStartedSignal.resolve();
+      let settlement;
+      try {
+        settlement = await resourceServer.settlePayment(paymentPayload, matched);
+      } catch (error) {
+        state.settlementError = error;
+        settlementSignal.resolve(state);
+        sendJson(response, 502, { error: "Settlement transport failed" });
+        return;
+      }
+      state.settlement = settlement;
+      settlementSignal.resolve(state);
+      if (!settlement.success) {
+        sendJson(response, 402, { error: settlement.errorReason ?? "Settlement failed" }, {
+          "payment-response": encodePaymentResponseHeader(settlement),
+        });
+        return;
+      }
+      sendJson(response, 200, {
+        ok: true,
+        resource: "FastNEAR x402 testnet fixture",
+        payer: settlement.payer,
+        transaction: settlement.transaction,
+      }, {
+        "payment-response": encodePaymentResponseHeader(settlement),
+      });
+    } catch (error) {
+      state.requestError = error;
+      const status = error instanceof HttpInputError ? error.status : 500;
+      sendJson(response, status, {
+        error: status === 500 ? "Seller transport failed" : safeErrorMessage(error),
+      });
+    }
+  }), 120_000);
+
+  try {
+    endpoint = await listenLoopback(server, options.mode === "serve-wallet" ? options.port : 0);
+    resourceInfo = protectedResourceInfo(`${endpoint.url}/paid`);
+    [requirements] = await resourceServer.buildPaymentRequirementsFromOptions([{
+      scheme: "exact",
+      network: NETWORK,
+      payTo: options.payTo,
+      price: { asset: options.asset, amount: options.amountText },
+      maxTimeoutSeconds: MAX_TIMEOUT_SECONDS,
+    }], {});
+    paymentRequired = await resourceServer.createPaymentRequiredResponse(
+      [requirements],
+      resourceInfo,
+    );
+    state.requirements = requirements;
+
+    const ensureBaseline = () => {
+      state.baselinePromise ??= captureBaseline();
+      return state.baselinePromise;
+    };
+    return {
+      ...endpoint,
+      server,
+      state,
+      settlementSignal,
+      paymentStartedSignal,
+      requirements,
+      paymentRequired,
+      ensureBaseline,
+    };
+  } catch (error) {
+    await closeServer(server);
+    throw error;
+  }
+}
+
+async function startTopology(options, credentials, rpcProxy, captureBaseline) {
+  const facilitator = createNearFacilitator({
+    registrations: [{
+      network: NETWORK,
+      signer: {
+        relayers: [{
+          accountId: options.relayer,
+          secretKey: credentials.relayer.secretKey,
+        }],
+        rpcUrls: { [NETWORK]: rpcProxy.url },
+      },
+      settlementCache: new SettlementCache(),
+    }],
+  });
+  let seller;
+  try {
+    const resourceServer = createNearResourceServer({
+      facilitators: facilitator,
+    });
+    await resourceServer.initialize();
+    const walletAssets = options.mode === "serve-wallet"
+      ? await loadWalletAssets(options.bundleVersion)
+      : undefined;
+    seller = await startSellerServer(
+      resourceServer,
+      options,
+      walletAssets,
+      captureBaseline,
+    );
+    return { resourceServer, seller };
+  } catch (error) {
+    await closeServer(seller?.server);
+    throw error;
+  }
+}
+
+function assertChallenge(challenge, options) {
+  invariant(challenge.x402Version === 2, "Seller challenge is not x402 v2");
+  invariant(challenge.accepts.length === 1, "Seller challenge must contain one requirement");
+  const accepted = challenge.accepts[0];
+  invariant(accepted.scheme === "exact", "Seller challenge scheme is not exact");
+  invariant(accepted.network === NETWORK, "Seller challenge network is not near:testnet");
+  invariant(accepted.asset === options.asset, "Seller challenge token does not match the fixture");
+  invariant(accepted.amount === options.amountText, "Seller challenge amount does not match the fixture");
+  invariant(accepted.payTo === options.payTo, "Seller challenge recipient does not match the fixture");
+  invariant(
+    accepted.maxTimeoutSeconds === MAX_TIMEOUT_SECONDS,
+    "Seller challenge timeout does not match the fixture",
+  );
+}
+
+async function runCheckOnly(topology, rpcProxy, options) {
+  const response = await fetch(`${topology.seller.url}/paid`);
+  invariant(response.status === 402, "Unpaid seller request did not return HTTP 402");
+  const header = response.headers.get("payment-required");
+  invariant(header, "Unpaid seller response omitted PAYMENT-REQUIRED");
+  assertChallenge(decodePaymentRequiredHeader(header), options);
+
+  invariant(rpcProxy.submissions.length === 0, "Check-only mode observed a transaction submission");
+  console.log("Check-only PASS: in-process facilitator support and the 402 challenge are wired");
+  console.log("No payment was signed and no transaction was submitted");
+}
+
+function firstClientSigningHeight(records) {
+  const record = records.find(item => item.request?.method === "block");
+  const height = record?.response?.result?.header?.height;
+  invariant(height !== undefined, "Could not identify the local signer's final block height");
+  return BigInt(height);
+}
+
+async function replaySettlement(topology, rpcProxy) {
+  const { payment, requirements } = topology.seller.state;
+  const replay = await topology.resourceServer.settlePayment(payment, requirements);
+  invariant(replay.success === false, "A finalized signed delegate was settled twice");
+  invariant(
+    replay.errorReason === "invalid_exact_near_payload_delegate_action_nonce_already_used",
+    `Finalized replay failed for an unexpected reason: ${replay.errorReason ?? "missing reason"}`,
+  );
+  invariant(rpcProxy.submissions.length === 1, "Replay caused a second transaction submission");
+}
+
+async function reconcileSettlement(topology, rpcProxy, options, credentials) {
+  const state = topology.seller.state;
+  if (state.settlementError) throw state.settlementError;
+  invariant(state.payment, "Seller did not capture a payment payload");
+  invariant(state.settlement?.success, `Settlement failed: ${state.settlement?.errorReason ?? "unknown error"}`);
+  invariant(state.settlement.payer === options.payer, "Settlement payer does not match the fixture");
+  invariant(state.settlement.network === NETWORK, "Settlement network does not match the fixture");
+  invariant(rpcProxy.submissions.length === 1, "Settlement did not submit exactly one transaction");
+  invariant(state.baselinePromise, "Seller did not capture a pre-signing chain baseline");
+  const before = await state.baselinePromise;
+
+  const signedDelegateAction = state.payment.payload?.signedDelegateAction;
+  invariant(typeof signedDelegateAction === "string", "Payment payload omitted its signed delegate action");
+  const signingHeight = options.mode === "execute"
+    ? firstClientSigningHeight(rpcProxy.records)
+    : undefined;
+  const decodedDelegate = decodeAndAssertDelegate(signedDelegateAction, {
+    payer: options.payer,
+    relayer: options.relayer,
+    asset: options.asset,
+    payTo: options.payTo,
+    amountText: options.amountText,
+    publicKey: credentials.payer?.publicKey,
+    nonce: before.payerKey ? BigInt(before.payerKey.nonce) + 1n : undefined,
+    maxBlockHeight: signingHeight === undefined
+      ? undefined
+      : signingHeight + BigInt(MAX_TIMEOUT_SECONDS),
+  });
+  if (options.mode === "serve-wallet") {
+    invariant(
+      decodedDelegate.delegate.maxBlockHeight > before.blockHeight,
+      "Wallet delegate was already expired when the smoke server started",
+    );
+  }
+
+  const submission = rpcProxy.submissions[0];
+  invariant(
+    submission.encodedDelegate === signedDelegateAction,
+    "Outer transaction did not embed the exact payment delegate bytes",
+  );
+  invariant(
+    submission.decoded.transaction.nonce === BigInt(before.relayerKey.nonce) + 1n,
+    "Outer transaction nonce is not the relayer access-key nonce plus one",
+  );
+  const transactionHash = submission.response?.result?.transaction_outcome?.id;
+  invariant(typeof transactionHash === "string", "send_tx response omitted the transaction hash");
+  invariant(
+    state.settlement.transaction === transactionHash,
+    "PAYMENT-RESPONSE transaction does not match the submitted transaction",
+  );
+
+  await replaySettlement(topology, rpcProxy);
+  const after = await collectChainSnapshot(
+    rpcProxy.url,
+    options,
+    decodedDelegate.delegate.publicKey,
+    credentials.relayer.publicKey,
+  );
+  invariant(after.payerToken === before.payerToken - options.amount, "Payer token delta is not exactly -amount");
+  invariant(after.payToToken === before.payToToken + options.amount, "Recipient token delta is not exactly +amount");
+  invariant(
+    BigInt(after.payerAccount.amount) === BigInt(before.payerAccount.amount),
+    "Payer native NEAR balance changed during sponsored settlement",
+  );
+  invariant(
+    BigInt(after.relayerAccount.amount) < BigInt(before.relayerAccount.amount),
+    "Relayer native NEAR balance did not pay settlement costs",
+  );
+  invariant(
+    BigInt(after.payerKey.nonce) === decodedDelegate.delegate.nonce,
+    "Payer access-key nonce did not finalize at the delegate nonce",
+  );
+  invariant(
+    BigInt(after.relayerKey.nonce) === BigInt(before.relayerKey.nonce) + 1n,
+    "Relayer access-key nonce did not advance exactly once",
+  );
+  console.log(`Settlement PASS: ${transactionHash}`);
+  console.log("Reconciliation PASS: exact token deltas, sponsored costs, both nonces, and replay rejection");
+  return transactionHash;
+}
+
+async function runExecute(topology, rpcProxy, options, credentials) {
+  await topology.seller.ensureBaseline();
+  rpcProxy.resetRecords();
+  const signer = createLocalNearSigner({
+    accountId: options.payer,
+    secretKey: credentials.payer.secretKey,
+    rpcUrls: { [NETWORK]: rpcProxy.url },
+  });
+  const paidFetch = createNearPaymentFetch({ signer, network: NETWORK });
+  const response = await paidFetch(`${topology.seller.url}/paid`);
+  if (response.status !== 200 && topology.seller.state.requestError) {
+    throw topology.seller.state.requestError;
+  }
+  if (response.status !== 200 && topology.seller.state.settlement) {
+    const proxyError = rpcProxy.errors.at(-1);
+    if (proxyError) throw proxyError;
+    throw new Error(
+      `Settlement failed: ${topology.seller.state.settlement.errorReason ?? "unknown error"}` +
+        (topology.seller.state.settlement.errorMessage
+          ? ` (${topology.seller.state.settlement.errorMessage})`
+          : ""),
+    );
+  }
+  invariant(response.status === 200, `Paid seller request returned HTTP ${response.status}`);
+  const paymentResponseHeader = response.headers.get("payment-response");
+  invariant(paymentResponseHeader, "Paid response omitted PAYMENT-RESPONSE");
+  const paymentResponse = decodePaymentResponseHeader(paymentResponseHeader);
+  invariant(paymentResponse.success, "PAYMENT-RESPONSE reports a failed settlement");
+  invariant(topology.seller.state.hits === 2, "Paid fetch did not perform exactly one 402 retry");
+  const body = await response.json();
+  invariant(body.ok === true, "Paid seller response body did not report success");
+  invariant(
+    paymentResponse.transaction === topology.seller.state.settlement?.transaction,
+    "PAYMENT-RESPONSE header does not match the seller settlement",
+  );
+  await reconcileSettlement(topology, rpcProxy, options, credentials);
+}
+
+async function waitForWalletSettlement(topology, signal, timeoutSeconds) {
+  if (signal.aborted) throw signal.reason;
+  let timer;
+  try {
+    const outcome = await Promise.race([
+      topology.seller.settlementSignal.promise.then(state => ({ kind: "settled", state })),
+      topology.seller.paymentStartedSignal.promise.then(() => ({ kind: "started" })),
+      new Promise((_, reject) => {
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+      }),
+      new Promise((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`Wallet session timed out after ${timeoutSeconds} seconds`)),
+          timeoutSeconds * 1_000,
+        );
+      }),
+    ]);
+    if (outcome.kind === "settled") return outcome.state;
+
+    // The session timeout protects an idle browser listener. Once the seller
+    // has claimed a verified payment, let the bounded RPC settlement path
+    // finish so shutdown cannot create an avoidable unknown-status result.
+    return await topology.seller.settlementSignal.promise;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function runServeWallet(topology, rpcProxy, options, credentials, signal) {
+  rpcProxy.resetRecords();
+  console.log(`Wallet QA page: ${topology.seller.url}/x402.html`);
+  console.log(`Expected wallet account: ${options.payer}`);
+  console.log(`Expected wallet: ${options.expectedWallet}`);
+  console.log(
+    options.bundleVersion === undefined
+      ? "Browser bundles: local dist"
+      : `Browser bundles: immutable npm version ${options.bundleVersion}`,
+  );
+  console.log("The server is loopback-only and will accept one settlement, then shut down");
+  const state = await waitForWalletSettlement(
+    topology,
+    signal,
+    options.walletTimeoutSeconds,
+  );
+  if (state.settlementError) throw state.settlementError;
+  await reconcileSettlement(topology, rpcProxy, options, credentials);
+  console.log(`Wallet QA record: ${state.walletName}`);
+  console.log("Wallet smoke PASS; the one-shot server is closing");
+}
+
+function clearCredentials(credentials) {
+  if (!credentials) return;
+  for (const credential of Object.values(credentials)) {
+    if (credential) credential.secretKey = "";
+  }
+}
+
+export async function runHarness(argv = process.argv.slice(2)) {
+  const values = parseHarnessArgs(argv);
+  const options = normalizeHarnessOptions(values);
+  if (options.mode === "help") {
+    console.log(HELP);
+    return;
+  }
+
+  let credentials;
+  let rpcProxy;
+  let topology;
+  const abortController = new AbortController();
+  const onSignal = signal => {
+    const settlementStarted = Boolean(
+      topology?.seller?.state?.payment || rpcProxy?.submissions?.length,
+    );
+    if (settlementStarted) {
+      console.error(
+        `Received ${signal} after payment processing began; waiting for bounded settlement reconciliation`,
+      );
+      return;
+    }
+    abortController.abort(new Error(`Received ${signal}`));
+  };
+  const onSigint = () => onSignal("SIGINT");
+  const onSigterm = () => onSignal("SIGTERM");
+  process.once("SIGINT", onSigint);
+  process.once("SIGTERM", onSigterm);
+
+  try {
+    credentials = await loadCredentials(options);
+    abortController.signal.throwIfAborted();
+    rpcProxy = await startRpcProxy(
+      options.rpcUrl,
+      options.mode !== "check",
+      {
+        payer: options.payer,
+        relayer: options.relayer,
+        asset: options.asset,
+        payTo: options.payTo,
+        amountText: options.amountText,
+        publicKey: credentials.payer?.publicKey,
+        relayerPublicKey: credentials.relayer.publicKey,
+        mode: options.mode,
+      },
+    );
+    await runPreflight(rpcProxy.url, options, credentials);
+    abortController.signal.throwIfAborted();
+    const captureBaseline = () => collectChainSnapshot(
+      rpcProxy.url,
+      options,
+      credentials.payer?.publicKey,
+      credentials.relayer.publicKey,
+    );
+    topology = await startTopology(options, credentials, rpcProxy, captureBaseline);
+    abortController.signal.throwIfAborted();
+
+    if (options.mode === "check") {
+      await runCheckOnly(topology, rpcProxy, options);
+    } else if (options.mode === "execute") {
+      await runExecute(topology, rpcProxy, options, credentials);
+    } else {
+      await runServeWallet(
+        topology,
+        rpcProxy,
+        options,
+        credentials,
+        abortController.signal,
+      );
+    }
+  } catch (error) {
+    const submission = rpcProxy?.submissions?.[0];
+    const transaction = topology?.seller?.state?.settlement?.transaction ??
+      submission?.response?.result?.transaction_outcome?.id ??
+      submission?.transactionHash;
+    if (submission) {
+      console.error(
+        `A settlement may have landed. Do not rerun automatically; reconcile with: near tx-status ${shellArg(transaction)} ${shellArg(options.relayer)} --networkId testnet`,
+      );
+    }
+    throw new Error(sanitizedErrorMessage(error, options.rpcUrl));
+  } finally {
+    process.removeListener("SIGINT", onSigint);
+    process.removeListener("SIGTERM", onSigterm);
+    await closeServer(topology?.seller?.server);
+    await closeServer(rpcProxy?.server);
+    clearCredentials(credentials);
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+) {
+  runHarness().catch(error => {
+    console.error(`x402 testnet smoke failed: ${safeErrorMessage(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/tsup-config.ts
+++ b/scripts/tsup-config.ts
@@ -11,6 +11,7 @@ export interface FastNearTsupOptions {
   bannerName: string;
   globalName: string;
   footer?: string;
+  moduleEntries?: Record<string, string>;
   sourceEntries?: string[];
   iifePlatform?: Options["platform"];
 }
@@ -32,22 +33,24 @@ function banner(manifest: PackageManifest, bannerName: string, format: string): 
 
 /**
  * Standard FastNear package build:
- * - CJS bundles package-internal modules into one resolvable entry while
+ * - CJS bundles each public module entry into a resolvable entry while
  *   retaining workspace/third-party dependencies as external requires.
  * - ESM remains unbundled and tree-shakeable.
- * - IIFE bundles every dependency into one browser-ready global.
+ * - IIFE bundles every dependency reachable from the root entry into one
+ *   browser-ready global.
  */
 export function createFastNearTsupConfig({
   manifest,
   bannerName,
   globalName,
   footer = lockedGlobalFooter(globalName),
+  moduleEntries = { index: "src/index.ts" },
   sourceEntries = ["src/**/*.ts", "!src/**/*.test.ts"],
   iifePlatform,
 }: FastNearTsupOptions) {
   return defineConfig([
     {
-      entry: { index: "src/index.ts" },
+      entry: moduleEntries,
       outDir: "dist/cjs",
       format: ["cjs"],
       bundle: true,
@@ -55,7 +58,7 @@ export function createFastNearTsupConfig({
       splitting: false,
       clean: true,
       keepNames: true,
-      dts: { resolve: true, entry: "src/index.ts" },
+      dts: { resolve: true, entry: moduleEntries },
       sourcemap: true,
       minify: false,
       banner: { js: banner(manifest, bannerName, "CJS") },
@@ -69,7 +72,7 @@ export function createFastNearTsupConfig({
       clean: true,
       keepNames: true,
       shims: true,
-      dts: { resolve: true, entry: "src/index.ts" },
+      dts: { resolve: true, entry: moduleEntries },
       sourcemap: true,
       minify: false,
       banner: { js: banner(manifest, bannerName, "ESM") },

--- a/scripts/verify-published-x402.mjs
+++ b/scripts/verify-published-x402.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+import { verifyPublishedX402 } from "./published-x402-helpers.mjs";
+
+const args = process.argv.slice(2);
+if (args.length !== 1) {
+  console.error(
+    "Usage: yarn smoke:x402:published <exact-version> (for example, 1.5.0-beta.0)",
+  );
+  process.exit(1);
+}
+
+try {
+  const result = await verifyPublishedX402(args[0]);
+  console.log(
+    `@fastnear/x402@${result.version}: npm integrity, ${result.nodeEntrypoints} CJS/ESM entrypoints, and ${result.iifeBytes}-byte immutable jsDelivr IIFE verified`,
+  );
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+}

--- a/scripts/x402-testnet-helpers.mjs
+++ b/scripts/x402-testnet-helpers.mjs
@@ -1,0 +1,309 @@
+import os from "node:os";
+import path from "node:path";
+import { parseArgs } from "node:util";
+
+export const MAX_PAYMENT_AMOUNT = 1_000_000n;
+export const MAX_TIMEOUT_SECONDS = 300;
+
+const OPTION_DEFINITIONS = {
+  "check-only": { type: "boolean" },
+  execute: { type: "boolean" },
+  "serve-wallet": { type: "boolean" },
+  help: { type: "boolean" },
+  payer: { type: "string" },
+  "payer-credential": { type: "string" },
+  relayer: { type: "string" },
+  "relayer-credential": { type: "string" },
+  "pay-to": { type: "string" },
+  asset: { type: "string" },
+  amount: { type: "string" },
+  "rpc-url": { type: "string" },
+  port: { type: "string" },
+  "confirm-network": { type: "string" },
+  "confirm-payer": { type: "string" },
+  "confirm-pay-to": { type: "string" },
+  "confirm-relayer": { type: "string" },
+  "confirm-asset": { type: "string" },
+  "confirm-amount": { type: "string" },
+  "expected-wallet": { type: "string" },
+  "bundle-version": { type: "string" },
+  "wallet-manifest": { type: "string" },
+  "wallet-timeout-seconds": { type: "string" },
+};
+
+const EXACT_SEMVER =
+  /^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const WALLET_CDN =
+  "https://cdn.jsdelivr.net/npm/@fastnear/wallet@next/dist/umd/browser.global.js";
+const X402_CDN =
+  "https://cdn.jsdelivr.net/npm/@fastnear/x402@next/dist/umd/browser.global.js";
+
+function exactBundleVersion(value) {
+  if (typeof value !== "string" || !EXACT_SEMVER.test(value)) {
+    throw new Error(
+      "--bundle-version must be an exact semver such as 1.5.0 or 1.5.0-beta.0",
+    );
+  }
+  return value;
+}
+
+function required(values, name) {
+  const value = values[name];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Missing required --${name} option`);
+  }
+  return value;
+}
+
+function expandHome(filename) {
+  if (filename === "~") return os.homedir();
+  if (filename.startsWith(`~${path.sep}`)) {
+    return path.join(os.homedir(), filename.slice(2));
+  }
+  return filename;
+}
+
+function namedTestnetAccount(value, label) {
+  if (!value.endsWith(".testnet") || value.length > 64) {
+    throw new Error(`${label} must be a named .testnet account`);
+  }
+  return value;
+}
+
+function testnetAsset(value) {
+  if (
+    (value.endsWith(".testnet") && value.length <= 64) ||
+    /^[0-9a-f]{64}$/.test(value)
+  ) {
+    return value;
+  }
+  throw new Error("--asset must be a named .testnet or 64-character implicit account");
+}
+
+function parsePort(value) {
+  if (!/^(?:0|[1-9][0-9]*)$/.test(value)) {
+    throw new Error("--port must be an integer from 0 through 65535");
+  }
+  const port = Number(value);
+  if (!Number.isSafeInteger(port) || port > 65_535) {
+    throw new Error("--port must be an integer from 0 through 65535");
+  }
+  return port;
+}
+
+export function parseHarnessArgs(argv) {
+  const parsed = parseArgs({
+    args: argv,
+    options: OPTION_DEFINITIONS,
+    strict: true,
+    allowPositionals: false,
+    tokens: true,
+  });
+
+  const seen = new Set();
+  for (const token of parsed.tokens) {
+    if (token.kind !== "option") continue;
+    if (seen.has(token.name)) {
+      throw new Error(`Option --${token.name} may only be provided once`);
+    }
+    seen.add(token.name);
+  }
+
+  return parsed.values;
+}
+
+export function normalizeHarnessOptions(values) {
+  if (values.help) return { mode: "help" };
+
+  const selectedModes = [
+    values["check-only"] ? "check" : null,
+    values.execute ? "execute" : null,
+    values["serve-wallet"] ? "serve-wallet" : null,
+  ].filter(Boolean);
+  if (selectedModes.length > 1) {
+    throw new Error("Choose only one of --check-only, --execute, or --serve-wallet");
+  }
+  const mode = selectedModes[0] ?? "check";
+
+  const payer = namedTestnetAccount(required(values, "payer"), "--payer");
+  const relayer = namedTestnetAccount(required(values, "relayer"), "--relayer");
+  const payTo = namedTestnetAccount(required(values, "pay-to"), "--pay-to");
+  if (new Set([payer, relayer, payTo]).size !== 3) {
+    throw new Error("Payer, relayer, and recipient must be three distinct accounts");
+  }
+
+  const asset = testnetAsset(required(values, "asset"));
+  const amountText = required(values, "amount");
+  if (!/^[1-9][0-9]*$/.test(amountText)) {
+    throw new Error("--amount must be a positive integer in atomic token units");
+  }
+  const amount = BigInt(amountText);
+  if (amount > MAX_PAYMENT_AMOUNT) {
+    throw new Error(
+      `--amount exceeds this harness's hard cap of ${MAX_PAYMENT_AMOUNT} atomic units`,
+    );
+  }
+
+  const rpcUrl = new URL(required(values, "rpc-url"));
+  if (rpcUrl.protocol !== "https:") {
+    throw new Error("--rpc-url must use HTTPS");
+  }
+  if (rpcUrl.username || rpcUrl.password) {
+    throw new Error("--rpc-url must not contain embedded credentials");
+  }
+  rpcUrl.hash = "";
+
+  const payerCredential = values["payer-credential"];
+  if (mode === "serve-wallet") {
+    if (payerCredential !== undefined) {
+      throw new Error("--payer-credential is forbidden with --serve-wallet");
+    }
+  } else if (typeof payerCredential !== "string" || payerCredential.length === 0) {
+    throw new Error("Missing required --payer-credential option");
+  }
+
+  const relayerCredential = required(values, "relayer-credential");
+  const port = values.port === undefined ? 0 : parsePort(values.port);
+  if (mode !== "serve-wallet" && values.port !== undefined) {
+    throw new Error("--port is only valid with --serve-wallet");
+  }
+
+  let expectedWallet;
+  let bundleVersion;
+  let walletManifest;
+  let walletTimeoutSeconds;
+  if (mode === "serve-wallet") {
+    expectedWallet = required(values, "expected-wallet");
+    if (expectedWallet.length > 100 || /[\r\n]/.test(expectedWallet)) {
+      throw new Error("--expected-wallet must be a single wallet name of 100 characters or fewer");
+    }
+    if (values["bundle-version"] !== undefined) {
+      bundleVersion = exactBundleVersion(values["bundle-version"]);
+    }
+    if (values["wallet-manifest"] !== undefined) {
+      const manifestUrl = new URL(values["wallet-manifest"]);
+      if (
+        manifestUrl.protocol !== "https:" ||
+        manifestUrl.username ||
+        manifestUrl.password ||
+        manifestUrl.search
+      ) {
+        throw new Error("--wallet-manifest must be an HTTPS URL without credentials or a query string");
+      }
+      manifestUrl.hash = "";
+      walletManifest = manifestUrl.href;
+    }
+    const timeoutText = values["wallet-timeout-seconds"] ?? "900";
+    if (!/^[1-9][0-9]*$/.test(timeoutText)) {
+      throw new Error("--wallet-timeout-seconds must be an integer from 1 through 3600");
+    }
+    walletTimeoutSeconds = Number(timeoutText);
+    if (!Number.isSafeInteger(walletTimeoutSeconds) || walletTimeoutSeconds > 3_600) {
+      throw new Error("--wallet-timeout-seconds must be an integer from 1 through 3600");
+    }
+  } else {
+    for (const name of [
+      "expected-wallet",
+      "bundle-version",
+      "wallet-manifest",
+      "wallet-timeout-seconds",
+    ]) {
+      if (values[name] !== undefined) {
+        throw new Error(`--${name} is only valid with --serve-wallet`);
+      }
+    }
+  }
+
+  if (mode === "check") {
+    for (const name of [
+      "confirm-network",
+      "confirm-payer",
+      "confirm-pay-to",
+      "confirm-relayer",
+      "confirm-asset",
+      "confirm-amount",
+    ]) {
+      if (values[name] !== undefined) {
+        throw new Error(`--${name} is only valid for a state-changing mode`);
+      }
+    }
+  } else {
+    if (values["confirm-network"] !== "testnet") {
+      throw new Error("State-changing modes require --confirm-network testnet");
+    }
+    if (values["confirm-payer"] !== payer) {
+      throw new Error("--confirm-payer must exactly match --payer");
+    }
+    if (values["confirm-pay-to"] !== payTo) {
+      throw new Error("--confirm-pay-to must exactly match --pay-to");
+    }
+    if (values["confirm-relayer"] !== relayer) {
+      throw new Error("--confirm-relayer must exactly match --relayer");
+    }
+    if (values["confirm-asset"] !== asset) {
+      throw new Error("--confirm-asset must exactly match --asset");
+    }
+    if (values["confirm-amount"] !== amountText) {
+      throw new Error("--confirm-amount must exactly match --amount");
+    }
+  }
+
+  return {
+    mode,
+    payer,
+    payerCredential: payerCredential
+      ? path.resolve(expandHome(payerCredential))
+      : undefined,
+    relayer,
+    relayerCredential: path.resolve(expandHome(relayerCredential)),
+    payTo,
+    asset,
+    amount,
+    amountText,
+    rpcUrl,
+    port,
+    expectedWallet,
+    bundleVersion,
+    walletManifest,
+    walletTimeoutSeconds,
+  };
+}
+
+export function sanitizedRpcUrl(url) {
+  return url.pathname === "/" ? url.origin : `${url.origin}/<redacted-path>`;
+}
+
+export function credentialMetadataError(metadata, currentUid) {
+  if (!metadata.isFile()) return "Credential path is not a regular file";
+  if ((metadata.mode & 0o077) !== 0) {
+    return `Credential permissions are too broad (mode ${(metadata.mode & 0o777).toString(8)})`;
+  }
+  if (currentUid !== undefined && metadata.uid !== currentUid) {
+    return "Credential file is not owned by the current user";
+  }
+  if (metadata.size > 64 * 1024) return "Credential file is unexpectedly large";
+  return null;
+}
+
+export function transformWalletSmokePage(html, config, bundleVersion) {
+  const serialized = JSON.stringify(config).replaceAll("<", "\\u003c");
+  const injection = `<script>globalThis.__FASTNEAR_X402_SMOKE__=${serialized};</script>`;
+  const version = bundleVersion === undefined
+    ? undefined
+    : exactBundleVersion(bundleVersion);
+  const walletBundle = version === undefined
+    ? "/bundles/wallet.js"
+    : WALLET_CDN.replace("@next/", `@${version}/`);
+  const x402Bundle = version === undefined
+    ? "/bundles/x402.js"
+    : X402_CDN.replace("@next/", `@${version}/`);
+
+  if (!html.includes(WALLET_CDN) || !html.includes(X402_CDN) || !html.includes("</head>")) {
+    throw new Error("The static x402 page no longer matches the wallet-smoke template");
+  }
+
+  return html
+    .replace(WALLET_CDN, walletBundle)
+    .replace(X402_CDN, x402Bundle)
+    .replace("</head>", `${injection}\n</head>`);
+}

--- a/scripts/x402-testnet-helpers.mjs
+++ b/scripts/x402-testnet-helpers.mjs
@@ -33,10 +33,18 @@ const OPTION_DEFINITIONS = {
 
 const EXACT_SEMVER =
   /^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const EXACT_SEMVER_SOURCE =
+  "(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?";
 const WALLET_CDN =
   "https://cdn.jsdelivr.net/npm/@fastnear/wallet@next/dist/umd/browser.global.js";
 const X402_CDN =
   "https://cdn.jsdelivr.net/npm/@fastnear/x402@next/dist/umd/browser.global.js";
+const WALLET_CDN_RE = new RegExp(
+  `https://cdn\\.jsdelivr\\.net/npm/@fastnear/wallet@(?:next|${EXACT_SEMVER_SOURCE})/dist/umd/browser\\.global\\.js`,
+);
+const X402_CDN_RE = new RegExp(
+  `https://cdn\\.jsdelivr\\.net/npm/@fastnear/x402@(?:next|${EXACT_SEMVER_SOURCE})/dist/umd/browser\\.global\\.js`,
+);
 
 function exactBundleVersion(value) {
   if (typeof value !== "string" || !EXACT_SEMVER.test(value)) {
@@ -298,12 +306,12 @@ export function transformWalletSmokePage(html, config, bundleVersion) {
     ? "/bundles/x402.js"
     : X402_CDN.replace("@next/", `@${version}/`);
 
-  if (!html.includes(WALLET_CDN) || !html.includes(X402_CDN) || !html.includes("</head>")) {
+  if (!WALLET_CDN_RE.test(html) || !X402_CDN_RE.test(html) || !html.includes("</head>")) {
     throw new Error("The static x402 page no longer matches the wallet-smoke template");
   }
 
   return html
-    .replace(WALLET_CDN, walletBundle)
-    .replace(X402_CDN, x402Bundle)
+    .replace(WALLET_CDN_RE, walletBundle)
+    .replace(X402_CDN_RE, x402Bundle)
     .replace("</head>", `${injection}\n</head>`);
 }

--- a/scripts/x402-testnet-helpers.test.mjs
+++ b/scripts/x402-testnet-helpers.test.mjs
@@ -1,0 +1,201 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import {
+  credentialMetadataError,
+  normalizeHarnessOptions,
+  parseHarnessArgs,
+  sanitizedRpcUrl,
+  transformWalletSmokePage,
+} from "./x402-testnet-helpers.mjs";
+
+const required = [
+  "--payer", "mike.testnet",
+  "--payer-credential", "/tmp/payer.json",
+  "--relayer", "relayer.mike.testnet",
+  "--relayer-credential", "/tmp/relayer.json",
+  "--pay-to", "merchant.mike.testnet",
+  "--asset", "wrap.testnet",
+  "--amount", "1",
+  "--rpc-url", "https://rpc.testnet.fastnear.com/private?token=hidden",
+];
+
+describe("x402 testnet harness options", () => {
+  it("defaults to the read-only check and strips RPC secrets from display", () => {
+    const options = normalizeHarnessOptions(parseHarnessArgs(required));
+    expect(options).toMatchObject({
+      mode: "check",
+      payer: "mike.testnet",
+      relayer: "relayer.mike.testnet",
+      payTo: "merchant.mike.testnet",
+      asset: "wrap.testnet",
+      amount: 1n,
+    });
+    expect(sanitizedRpcUrl(options.rpcUrl)).toBe(
+      "https://rpc.testnet.fastnear.com/<redacted-path>",
+    );
+  });
+
+  it("requires confirmations for execution", () => {
+    expect(() => normalizeHarnessOptions(parseHarnessArgs([
+      ...required,
+      "--execute",
+    ]))).toThrow("--confirm-network testnet");
+
+    expect(normalizeHarnessOptions(parseHarnessArgs([
+      ...required,
+      "--execute",
+      "--confirm-network", "testnet",
+      "--confirm-payer", "mike.testnet",
+      "--confirm-pay-to", "merchant.mike.testnet",
+      "--confirm-relayer", "relayer.mike.testnet",
+      "--confirm-asset", "wrap.testnet",
+      "--confirm-amount", "1",
+    ])).mode).toBe("execute");
+  });
+
+  it("forbids a local payer key in wallet mode and rejects duplicate flags", () => {
+    expect(() => parseHarnessArgs([...required, "--amount", "2"])).toThrow(
+      "Option --amount may only be provided once",
+    );
+    expect(() => normalizeHarnessOptions(parseHarnessArgs([
+      ...required,
+      "--serve-wallet",
+      "--confirm-network", "testnet",
+      "--confirm-payer", "mike.testnet",
+      "--confirm-pay-to", "merchant.mike.testnet",
+      "--confirm-relayer", "relayer.mike.testnet",
+      "--confirm-asset", "wrap.testnet",
+      "--confirm-amount", "1",
+      "--expected-wallet", "Intear Wallet",
+    ]))).toThrow("--payer-credential is forbidden");
+  });
+
+  it("locks wallet mode to an exact wallet and optional public manifest", () => {
+    const withoutPayerCredential = required.filter((_, index) =>
+      index !== 2 && index !== 3
+    );
+    const options = normalizeHarnessOptions(parseHarnessArgs([
+      ...withoutPayerCredential,
+      "--serve-wallet",
+      "--confirm-network", "testnet",
+      "--confirm-payer", "mike.testnet",
+      "--confirm-pay-to", "merchant.mike.testnet",
+      "--confirm-relayer", "relayer.mike.testnet",
+      "--confirm-asset", "wrap.testnet",
+      "--confirm-amount", "1",
+      "--expected-wallet", "Meteor Wallet",
+      "--bundle-version", "1.5.0-beta.0",
+      "--wallet-manifest", "https://wallets.example.test/candidate.json",
+      "--wallet-timeout-seconds", "60",
+    ]));
+    expect(options).toMatchObject({
+      mode: "serve-wallet",
+      expectedWallet: "Meteor Wallet",
+      bundleVersion: "1.5.0-beta.0",
+      walletManifest: "https://wallets.example.test/candidate.json",
+      walletTimeoutSeconds: 60,
+    });
+  });
+
+  it("accepts only exact published bundle versions in wallet mode", () => {
+    const withoutPayerCredential = required.filter((_, index) =>
+      index !== 2 && index !== 3
+    );
+    const walletArgs = [
+      ...withoutPayerCredential,
+      "--serve-wallet",
+      "--confirm-network", "testnet",
+      "--confirm-payer", "mike.testnet",
+      "--confirm-pay-to", "merchant.mike.testnet",
+      "--confirm-relayer", "relayer.mike.testnet",
+      "--confirm-asset", "wrap.testnet",
+      "--confirm-amount", "1",
+      "--expected-wallet", "Meteor Wallet",
+    ];
+
+    for (const version of [
+      "next",
+      "^1.5.0",
+      "v1.5.0",
+      "1.5",
+      "01.5.0",
+      "1.5.0-beta..0",
+      "1.5.0-01",
+    ]) {
+      expect(() => normalizeHarnessOptions(parseHarnessArgs([
+        ...walletArgs,
+        "--bundle-version", version,
+      ])), version).toThrow("--bundle-version must be an exact semver");
+    }
+
+    expect(() => normalizeHarnessOptions(parseHarnessArgs([
+      ...required,
+      "--bundle-version", "1.5.0",
+    ]))).toThrow("--bundle-version is only valid with --serve-wallet");
+  });
+
+  it("rejects broad credential modes", () => {
+    const metadata = {
+      isFile: () => true,
+      mode: 0o100644,
+      uid: 501,
+      size: 200,
+    };
+    expect(credentialMetadataError(metadata, 501)).toContain("mode 644");
+    metadata.mode = 0o100600;
+    expect(credentialMetadataError(metadata, 501)).toBeNull();
+  });
+
+  it("locks the served page to local bundles and escaped fixture data", () => {
+    const html = `
+      <script src="https://cdn.jsdelivr.net/npm/@fastnear/wallet@next/dist/umd/browser.global.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/@fastnear/x402@next/dist/umd/browser.global.js"></script>
+      </head>`;
+    const result = transformWalletSmokePage(html, { payer: "<mike.testnet>" });
+    expect(result).toContain("/bundles/wallet.js");
+    expect(result).toContain("/bundles/x402.js");
+    expect(result).toContain("\\u003cmike.testnet>");
+    expect(result).not.toContain("@next");
+  });
+
+  it("locks the served page to immutable exact-version CDN bundles", () => {
+    const html = `
+      <script src="https://cdn.jsdelivr.net/npm/@fastnear/wallet@next/dist/umd/browser.global.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/@fastnear/x402@next/dist/umd/browser.global.js"></script>
+      </head>`;
+    const result = transformWalletSmokePage(
+      html,
+      { payer: "mike.testnet" },
+      "1.5.0-beta.0",
+    );
+    expect(result).toContain(
+      "https://cdn.jsdelivr.net/npm/@fastnear/wallet@1.5.0-beta.0/dist/umd/browser.global.js",
+    );
+    expect(result).toContain(
+      "https://cdn.jsdelivr.net/npm/@fastnear/x402@1.5.0-beta.0/dist/umd/browser.global.js",
+    );
+    expect(result).not.toContain("/bundles/wallet.js");
+    expect(result).not.toContain("@next");
+  });
+
+  it("never displays RPC query strings, credentials, or path tokens", () => {
+    expect(sanitizedRpcUrl(new URL(
+      "https://user:secret@rpc.example.test/v1/path-key?apiKey=query-key",
+    ))).toBe("https://rpc.example.test/<redacted-path>");
+    expect(sanitizedRpcUrl(new URL("https://rpc.example.test/"))).toBe(
+      "https://rpc.example.test",
+    );
+  });
+
+  it("transforms the repository's real wallet page", async () => {
+    const html = await readFile(new URL("../examples/static/x402.html", import.meta.url), "utf8");
+    const result = transformWalletSmokePage(html, {
+      payer: "mike.testnet",
+      expectedWallet: "Intear Wallet",
+    });
+    expect(result).toContain("globalThis.__FASTNEAR_X402_SMOKE__");
+    expect(result).toContain("/bundles/wallet.js");
+    expect(result).toContain("/bundles/x402.js");
+    expect(result).toContain("id=\"smoke-fixture\"");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,22 @@ export default defineConfig({
         __dirname,
         "packages/ml-dsa-65/src",
       ),
+      "@fastnear/x402/facilitator": path.resolve(
+        __dirname,
+        "packages/x402/src/facilitator.ts",
+      ),
+      "@fastnear/x402/server": path.resolve(
+        __dirname,
+        "packages/x402/src/server.ts",
+      ),
+      "@fastnear/x402/node": path.resolve(
+        __dirname,
+        "packages/x402/src/node.ts",
+      ),
+      "@fastnear/x402": path.resolve(
+        __dirname,
+        "packages/x402/src/index.ts",
+      ),
     },
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import path from "path";
 
 export default defineConfig({
   test: {
-    include: ["packages/*/src/**/*.test.ts"],
+    include: ["packages/*/src/**/*.test.ts", "scripts/**/*.test.mjs"],
   },
   resolve: {
     alias: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -674,11 +674,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fastnear/x402@workspace:packages/x402"
   dependencies:
-    "@fastnear/borsh": "workspace:*"
-    "@fastnear/borsh-schema": "workspace:*"
     "@fastnear/wallet": "workspace:*"
     "@near-js/transactions": "npm:*"
-    "@noble/secp256k1": "npm:*"
     "@x402/core": "npm:*"
     "@x402/fetch": "npm:*"
     "@x402/near": "npm:*"
@@ -968,13 +965,6 @@ __metadata:
     "@noble/curves": "npm:~2.0.0"
     "@noble/hashes": "npm:~2.0.0"
   checksum: 10c0/4c6d782acfc78b814f5ef38d7f8b4a2995a09f85f87e12e7e4fa2862ad3e2416b9b0d81cb93ed9c53e1dfd05f40e467e3fef0e12cc5d79009ae13ec42d502164
-  languageName: node
-  linkType: hard
-
-"@noble/secp256k1@npm:*, @noble/secp256k1@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "@noble/secp256k1@npm:3.1.0"
-  checksum: 10c0/5f40f90d7b67c714f168f6f455e50e7702c5d1ca6a970e93c3e53fec150c93cfb39b1fff74ea12c6351afe589ea58ec65f721233a55ff43d8d9ce2fac3860342
   languageName: node
   linkType: hard
 
@@ -2355,7 +2345,6 @@ __metadata:
     "@noble/curves": "npm:=2.0.1"
     "@noble/hashes": "npm:=2.0.1"
     "@noble/post-quantum": "npm:=0.6.0"
-    "@noble/secp256k1": "npm:^3.1.0"
     "@types/node": "npm:^22.13.1"
     "@walletconnect/sign-client": "npm:^2.23.7"
     "@x402/core": "npm:~2.18.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -659,7 +659,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fastnear/wallet@workspace:packages/wallet":
+"@fastnear/wallet@workspace:*, @fastnear/wallet@workspace:packages/wallet":
   version: 0.0.0-use.local
   resolution: "@fastnear/wallet@workspace:packages/wallet"
   dependencies:
@@ -667,6 +667,29 @@ __metadata:
     rimraf: "npm:*"
     tsup: "npm:^8.3.6"
     typescript: "npm:*"
+  languageName: unknown
+  linkType: soft
+
+"@fastnear/x402@workspace:packages/x402":
+  version: 0.0.0-use.local
+  resolution: "@fastnear/x402@workspace:packages/x402"
+  dependencies:
+    "@fastnear/borsh": "workspace:*"
+    "@fastnear/borsh-schema": "workspace:*"
+    "@fastnear/wallet": "workspace:*"
+    "@near-js/transactions": "npm:*"
+    "@noble/secp256k1": "npm:*"
+    "@x402/core": "npm:*"
+    "@x402/fetch": "npm:*"
+    "@x402/near": "npm:*"
+    rimraf: "npm:*"
+    tsup: "npm:^8.3.6"
+    typescript: "npm:*"
+  peerDependencies:
+    "@fastnear/wallet": "workspace:*"
+  peerDependenciesMeta:
+    "@fastnear/wallet":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -742,6 +765,114 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@near-js/crypto@npm:2.5.1, @near-js/crypto@npm:^2.5.1":
+  version: 2.5.1
+  resolution: "@near-js/crypto@npm:2.5.1"
+  dependencies:
+    "@near-js/types": "npm:2.5.1"
+    "@near-js/utils": "npm:2.5.1"
+    "@noble/curves": "npm:1.8.1"
+    "@noble/hashes": "npm:^1.7.1"
+    borsh: "npm:1.0.0"
+    secp256k1: "npm:5.0.1"
+  peerDependencies:
+    "@near-js/types": ^2.0.1
+    "@near-js/utils": ^2.0.1
+  checksum: 10c0/4b7bd929e3378b04c920f7f203e06ac9b48bc67f25322200438b27e2bb9cb3deedf79ff2c974f0f93c694555656b654705cff8de5e2fcb379087090138fd50e3
+  languageName: node
+  linkType: hard
+
+"@near-js/keystores@npm:2.5.1":
+  version: 2.5.1
+  resolution: "@near-js/keystores@npm:2.5.1"
+  dependencies:
+    "@near-js/crypto": "npm:2.5.1"
+    "@near-js/types": "npm:2.5.1"
+  peerDependencies:
+    "@near-js/crypto": ^2.0.1
+    "@near-js/types": ^2.0.1
+  checksum: 10c0/75fc81e454f0d1c7245d1b666f3a6e28faa8167cb87583a2243b3e003600a6ce118fb979e35d365787d166f4a2388a91e700fc829b3794fecbd54cee560e8198
+  languageName: node
+  linkType: hard
+
+"@near-js/providers@npm:^2.5.1":
+  version: 2.5.1
+  resolution: "@near-js/providers@npm:2.5.1"
+  dependencies:
+    "@near-js/crypto": "npm:2.5.1"
+    "@near-js/transactions": "npm:2.5.1"
+    "@near-js/types": "npm:2.5.1"
+    "@near-js/utils": "npm:2.5.1"
+    borsh: "npm:1.0.0"
+    exponential-backoff: "npm:^3.1.2"
+    node-fetch: "npm:2.6.7"
+  peerDependencies:
+    "@near-js/crypto": ^2.0.1
+    "@near-js/transactions": ^2.0.1
+    "@near-js/types": ^2.0.1
+    "@near-js/utils": ^2.0.1
+  dependenciesMeta:
+    node-fetch:
+      optional: true
+  checksum: 10c0/014e779b487d0c6f01770d2980142b791a72a82960b391a32d7b247abd5c8d8e892562c062db5077b346632fbc3a5d870f5816cf992b851810238ae72ec84d3a
+  languageName: node
+  linkType: hard
+
+"@near-js/signers@npm:^2.5.1":
+  version: 2.5.1
+  resolution: "@near-js/signers@npm:2.5.1"
+  dependencies:
+    "@near-js/crypto": "npm:2.5.1"
+    "@near-js/keystores": "npm:2.5.1"
+    "@near-js/transactions": "npm:2.5.1"
+    "@noble/hashes": "npm:1.7.1"
+    borsh: "npm:1.0.0"
+  peerDependencies:
+    "@near-js/crypto": ^2.0.1
+    "@near-js/keystores": ^2.0.1
+    "@near-js/transactions": ^2.0.1
+  checksum: 10c0/cc58a679629f18a09de9b7bd9e31461ab7ba382f34063276d8937b35950bc988125c143e8526a1affa8573dd6bfa9d9d2ac4b06b10af4a5e7bb10566122fb7c3
+  languageName: node
+  linkType: hard
+
+"@near-js/transactions@npm:*, @near-js/transactions@npm:2.5.1, @near-js/transactions@npm:^2.5.1":
+  version: 2.5.1
+  resolution: "@near-js/transactions@npm:2.5.1"
+  dependencies:
+    "@near-js/crypto": "npm:2.5.1"
+    "@near-js/types": "npm:2.5.1"
+    "@near-js/utils": "npm:2.5.1"
+    "@noble/hashes": "npm:1.7.1"
+    borsh: "npm:1.0.0"
+  peerDependencies:
+    "@near-js/crypto": ^2.0.1
+    "@near-js/types": ^2.0.1
+    "@near-js/utils": ^2.0.1
+  checksum: 10c0/544c0cc302c6740e5204a8ac1b64c76f94686ba99499dd06abce56ad712397c717adce1c8f0c8903693701823929979d06e1b291d4614fa443b98c87eeac6f97
+  languageName: node
+  linkType: hard
+
+"@near-js/types@npm:2.5.1":
+  version: 2.5.1
+  resolution: "@near-js/types@npm:2.5.1"
+  checksum: 10c0/4357b3fe1d352a76d225289b240e8b412a7f1f7c1101654f71da309fdb12607e5b0b532997bf657d662a46d2865e29414adc8aca9d18230b210fb4c8776bd693
+  languageName: node
+  linkType: hard
+
+"@near-js/utils@npm:2.5.1, @near-js/utils@npm:^2.5.1":
+  version: 2.5.1
+  resolution: "@near-js/utils@npm:2.5.1"
+  dependencies:
+    "@near-js/types": "npm:2.5.1"
+    "@scure/base": "npm:^1.2.4"
+    depd: "npm:2.0.0"
+    mustache: "npm:4.0.0"
+  peerDependencies:
+    "@near-js/types": ^2.0.1
+  checksum: 10c0/c527b60d99200aaa512fdf0788242a47fe9c1a874d972f5d250060acbdf1658069fb9c34c0616f47e7eb93acf53ac5df72b126e7a1cc3533edbca6af1b520990
+  languageName: node
+  linkType: hard
+
 "@noble/ciphers@npm:1.3.0, @noble/ciphers@npm:^1.3.0":
   version: 1.3.0
   resolution: "@noble/ciphers@npm:1.3.0"
@@ -771,6 +902,15 @@ __metadata:
   dependencies:
     "@noble/hashes": "npm:1.7.0"
   checksum: 10c0/3ebb1795f3f7d74c879bc6262a3444061585a2cab90b7b637dc57d931063dd0c95be858a4c2389e932651825dbc461c215dbcf43984a232de3bd6b2d326ba555
+  languageName: node
+  linkType: hard
+
+"@noble/curves@npm:1.8.1":
+  version: 1.8.1
+  resolution: "@noble/curves@npm:1.8.1"
+  dependencies:
+    "@noble/hashes": "npm:1.7.1"
+  checksum: 10c0/84902c7af93338373a95d833f77981113e81c48d4bec78f22f63f1f7fdd893bc1d3d7a3ee78f01b9a8ad3dec812a1232866bf2ccbeb2b1560492e5e7d690ab1f
   languageName: node
   linkType: hard
 
@@ -806,7 +946,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:1.8.0, @noble/hashes@npm:^1.8.0, @noble/hashes@npm:~1.8.0":
+"@noble/hashes@npm:1.7.1":
+  version: 1.7.1
+  resolution: "@noble/hashes@npm:1.7.1"
+  checksum: 10c0/2f8ec0338ccc92b576a0f5c16ab9c017a3a494062f1fbb569ae641c5e7eab32072f9081acaa96b5048c0898f972916c818ea63cbedda707886a4b5ffcfbf94e3
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:1.8.0, @noble/hashes@npm:^1.7.1, @noble/hashes@npm:^1.8.0, @noble/hashes@npm:~1.8.0":
   version: 1.8.0
   resolution: "@noble/hashes@npm:1.8.0"
   checksum: 10c0/06a0b52c81a6fa7f04d67762e08b2c476a00285858150caeaaff4037356dd5e119f45b2a530f638b77a5eeca013168ec1b655db41bae3236cb2e9d511484fc77
@@ -821,6 +968,13 @@ __metadata:
     "@noble/curves": "npm:~2.0.0"
     "@noble/hashes": "npm:~2.0.0"
   checksum: 10c0/4c6d782acfc78b814f5ef38d7f8b4a2995a09f85f87e12e7e4fa2862ad3e2416b9b0d81cb93ed9c53e1dfd05f40e467e3fef0e12cc5d79009ae13ec42d502164
+  languageName: node
+  linkType: hard
+
+"@noble/secp256k1@npm:*, @noble/secp256k1@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@noble/secp256k1@npm:3.1.0"
+  checksum: 10c0/5f40f90d7b67c714f168f6f455e50e7702c5d1ca6a970e93c3e53fec150c93cfb39b1fff74ea12c6351afe589ea58ec65f721233a55ff43d8d9ce2fac3860342
   languageName: node
   linkType: hard
 
@@ -1028,7 +1182,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@scure/base@npm:1.2.6, @scure/base@npm:~1.2.5":
+"@scure/base@npm:1.2.6, @scure/base@npm:^1.2.4, @scure/base@npm:~1.2.5":
   version: 1.2.6
   resolution: "@scure/base@npm:1.2.6"
   checksum: 10c0/49bd5293371c4e062cb6ba689c8fe3ea3981b7bb9c000400dc4eafa29f56814cdcdd27c04311c2fec34de26bc373c593a1d6ca6d754398a488d587943b7c128a
@@ -1414,6 +1568,40 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@x402/core@npm:*, @x402/core@npm:~2.18.0":
+  version: 2.18.0
+  resolution: "@x402/core@npm:2.18.0"
+  dependencies:
+    zod: "npm:^3.24.2"
+  checksum: 10c0/9a2a17ceb84296998c6c27528068cbba1cc1876185fdc49ef8fe8ef911b7cee2e414525e800bd82ac9d5ab853d701fb2c14fdaac7c1cde6637e359f3bb144756
+  languageName: node
+  linkType: hard
+
+"@x402/fetch@npm:*, @x402/fetch@npm:~2.18.0":
+  version: 2.18.0
+  resolution: "@x402/fetch@npm:2.18.0"
+  dependencies:
+    "@x402/core": "npm:~2.18.0"
+  checksum: 10c0/7ebced306e7a915dd0954f1ff4c14dacd29e77794e960fe58e7a9d1c8aae6d2e842af5e9a5dcba18b1021666aa027179083d1130e9ea13a590ba539199c068a9
+  languageName: node
+  linkType: hard
+
+"@x402/near@npm:*, @x402/near@npm:~2.18.0":
+  version: 2.18.0
+  resolution: "@x402/near@npm:2.18.0"
+  dependencies:
+    "@near-js/crypto": "npm:^2.5.1"
+    "@near-js/providers": "npm:^2.5.1"
+    "@near-js/signers": "npm:^2.5.1"
+    "@near-js/transactions": "npm:^2.5.1"
+    "@near-js/utils": "npm:^2.5.1"
+    "@noble/hashes": "npm:^1.8.0"
+    "@x402/core": "npm:~2.18.0"
+    borsh: "npm:1.0.0"
+  checksum: 10c0/bb942349e12cffb574962e4ed45f7cdd6929f9d5a5929887ae1abf0c71e9d90959f058b2d2cdf8a7a068e6834a7a772064cd8951ee14e5279f4f1d3c8eb464af
+  languageName: node
+  linkType: hard
+
 "Base64@npm:~0.2.0":
   version: 0.2.1
   resolution: "Base64@npm:0.2.1"
@@ -1539,12 +1727,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bn.js@npm:^4.11.9":
+  version: 4.12.5
+  resolution: "bn.js@npm:4.12.5"
+  checksum: 10c0/e15e35d0e082fa43c5dd03b552041faf23bc870fbe5de0e41ab5d2d987875f43ffb1f8f57021494e9d71784223c59ddbba1819948b2c2648477a61ab7455aa42
+  languageName: node
+  linkType: hard
+
+"borsh@npm:1.0.0":
+  version: 1.0.0
+  resolution: "borsh@npm:1.0.0"
+  checksum: 10c0/dbf893af43e5efc6bc9ae2579d5c12514da72437311a30d8c3cfa77c1d51385e0b2a7242f193f7af980e71161ed9db524ab23301752b4401a1b8bfc47f09957b
+  languageName: node
+  linkType: hard
+
 "brace-expansion@npm:^2.0.2":
   version: 2.1.0
   resolution: "brace-expansion@npm:2.1.0"
   dependencies:
     balanced-match: "npm:^1.0.0"
   checksum: 10c0/439cedf3e23d7993b37919f1d6fdc653ec21a42437ec3e7460bea9ca8b17edf7a24a633273c31d61aa4335877cf29a443f1871814131c87997a1e6223e1f1502
+  languageName: node
+  linkType: hard
+
+"brorand@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "brorand@npm:1.1.0"
+  checksum: 10c0/6f366d7c4990f82c366e3878492ba9a372a73163c09871e80d82fb4ae0d23f9f8924cb8a662330308206e6b3b76ba1d528b4601c9ef73c2166b440b2ea3b7571
   languageName: node
   linkType: hard
 
@@ -1714,6 +1923,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"depd@npm:2.0.0":
+  version: 2.0.0
+  resolution: "depd@npm:2.0.0"
+  checksum: 10c0/58bd06ec20e19529b06f7ad07ddab60e504d9e0faca4bd23079fac2d279c3594334d736508dc350e06e510aba5e22e4594483b3a6562ce7c17dd797f4cc4ad2c
+  languageName: node
+  linkType: hard
+
 "destr@npm:^2.0.5":
   version: 2.0.5
   resolution: "destr@npm:2.0.5"
@@ -1732,6 +1948,21 @@ __metadata:
   version: 0.2.0
   resolution: "eastasianwidth@npm:0.2.0"
   checksum: 10c0/26f364ebcdb6395f95124fda411f63137a4bfb5d3a06453f7f23dfe52502905bd84e0488172e0f9ec295fdc45f05c23d5d91baf16bd26f0fe9acd777a188dc39
+  languageName: node
+  linkType: hard
+
+"elliptic@npm:^6.5.7":
+  version: 6.6.1
+  resolution: "elliptic@npm:6.6.1"
+  dependencies:
+    bn.js: "npm:^4.11.9"
+    brorand: "npm:^1.1.0"
+    hash.js: "npm:^1.0.0"
+    hmac-drbg: "npm:^1.0.1"
+    inherits: "npm:^2.0.4"
+    minimalistic-assert: "npm:^1.0.1"
+    minimalistic-crypto-utils: "npm:^1.0.1"
+  checksum: 10c0/8b24ef782eec8b472053793ea1e91ae6bee41afffdfcb78a81c0a53b191e715cbe1292aa07165958a9bbe675bd0955142560b1a007ffce7d6c765bcaf951a867
   languageName: node
   linkType: hard
 
@@ -2106,6 +2337,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"exponential-backoff@npm:^3.1.2":
+  version: 3.1.3
+  resolution: "exponential-backoff@npm:3.1.3"
+  checksum: 10c0/77e3ae682b7b1f4972f563c6dbcd2b0d54ac679e62d5d32f3e5085feba20483cf28bd505543f520e287a56d4d55a28d7874299941faf637e779a1aa5994d1267
+  languageName: node
+  linkType: hard
+
 "fastnear-js-monorepo@workspace:.":
   version: 0.0.0-use.local
   resolution: "fastnear-js-monorepo@workspace:."
@@ -2113,11 +2351,16 @@ __metadata:
     "@esbuild-plugins/node-globals-polyfill": "npm:^0.2.3"
     "@esbuild-plugins/node-modules-polyfill": "npm:^0.2.2"
     "@fastnear/near-connect": "npm:^0.12.1"
+    "@near-js/transactions": "npm:^2.5.1"
     "@noble/curves": "npm:=2.0.1"
     "@noble/hashes": "npm:=2.0.1"
     "@noble/post-quantum": "npm:=0.6.0"
+    "@noble/secp256k1": "npm:^3.1.0"
     "@types/node": "npm:^22.13.1"
     "@walletconnect/sign-client": "npm:^2.23.7"
+    "@x402/core": "npm:~2.18.0"
+    "@x402/fetch": "npm:~2.18.0"
+    "@x402/near": "npm:~2.18.0"
     base58-js: "npm:=2.0.0"
     esbuild: "npm:=0.27.3"
     events: "npm:^3.3.0"
@@ -2223,6 +2466,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hash.js@npm:^1.0.0, hash.js@npm:^1.0.3":
+  version: 1.1.7
+  resolution: "hash.js@npm:1.1.7"
+  dependencies:
+    inherits: "npm:^2.0.3"
+    minimalistic-assert: "npm:^1.0.1"
+  checksum: 10c0/41ada59494eac5332cfc1ce6b7ebdd7b88a3864a6d6b08a3ea8ef261332ed60f37f10877e0c825aaa4bddebf164fbffa618286aeeec5296675e2671cbfa746c4
+  languageName: node
+  linkType: hard
+
+"hmac-drbg@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "hmac-drbg@npm:1.0.1"
+  dependencies:
+    hash.js: "npm:^1.0.3"
+    minimalistic-assert: "npm:^1.0.0"
+    minimalistic-crypto-utils: "npm:^1.0.1"
+  checksum: 10c0/f3d9ba31b40257a573f162176ac5930109816036c59a09f901eb2ffd7e5e705c6832bedfff507957125f2086a0ab8f853c0df225642a88bf1fcaea945f20600d
+  languageName: node
+  linkType: hard
+
 "http-browserify@npm:^1.7.0":
   version: 1.7.0
   resolution: "http-browserify@npm:1.7.0"
@@ -2290,7 +2554,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:^2.0.3, inherits@npm:~2.0.1, inherits@npm:~2.0.4":
+"inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.1, inherits@npm:~2.0.4":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
@@ -2469,6 +2733,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimalistic-assert@npm:^1.0.0, minimalistic-assert@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "minimalistic-assert@npm:1.0.1"
+  checksum: 10c0/96730e5601cd31457f81a296f521eb56036e6f69133c0b18c13fe941109d53ad23a4204d946a0d638d7f3099482a0cec8c9bb6d642604612ce43ee536be3dddd
+  languageName: node
+  linkType: hard
+
+"minimalistic-crypto-utils@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "minimalistic-crypto-utils@npm:1.0.1"
+  checksum: 10c0/790ecec8c5c73973a4fbf2c663d911033e8494d5fb0960a4500634766ab05d6107d20af896ca2132e7031741f19888154d44b2408ada0852446705441383e9f8
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^9.0.7":
   version: 9.0.9
   resolution: "minimatch@npm:9.0.9"
@@ -2577,6 +2855,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mustache@npm:4.0.0":
+  version: 4.0.0
+  resolution: "mustache@npm:4.0.0"
+  bin:
+    mustache: ./bin/mustache
+  checksum: 10c0/63f7fdb50b55f1285c2c601d2bef760a2e10a3ea68b020358430141010fd990c11e58bb62e1da59363a6e0c74c27c2b7277965f5bcf9a831961a93959450c6ff
+  languageName: node
+  linkType: hard
+
 "mz@npm:^2.7.0":
   version: 2.7.0
   resolution: "mz@npm:2.7.0"
@@ -2604,10 +2891,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-addon-api@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "node-addon-api@npm:5.1.0"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/0eb269786124ba6fad9df8007a149e03c199b3e5a3038125dfb3e747c2d5113d406a4e33f4de1ea600aa2339be1f137d55eba1a73ee34e5fff06c52a5c296d1d
+  languageName: node
+  linkType: hard
+
 "node-fetch-native@npm:^1.6.7":
   version: 1.6.7
   resolution: "node-fetch-native@npm:1.6.7"
   checksum: 10c0/8b748300fb053d21ca4d3db9c3ff52593d5e8f8a2d9fe90cbfad159676e324b954fdaefab46aeca007b5b9edab3d150021c4846444e4e8ab1f4e44cd3807be87
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:2.6.7":
+  version: 2.6.7
+  resolution: "node-fetch@npm:2.6.7"
+  dependencies:
+    whatwg-url: "npm:^5.0.0"
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: 10c0/fcae80f5ac52fbf5012f5e19df2bd3915e67d3b3ad51cb5942943df2238d32ba15890fecabd0e166876a9f98a581ab50f3f10eb942b09405c49ef8da36b826c7
+  languageName: node
+  linkType: hard
+
+"node-gyp-build@npm:^4.2.0":
+  version: 4.8.4
+  resolution: "node-gyp-build@npm:4.8.4"
+  bin:
+    node-gyp-build: bin.js
+    node-gyp-build-optional: optional.js
+    node-gyp-build-test: build-test.js
+  checksum: 10c0/444e189907ece2081fe60e75368784f7782cfddb554b60123743dfb89509df89f1f29c03bbfa16b3a3e0be3f48799a4783f487da6203245fa5bed239ba7407e1
   languageName: node
   linkType: hard
 
@@ -3089,6 +3410,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"secp256k1@npm:5.0.1":
+  version: 5.0.1
+  resolution: "secp256k1@npm:5.0.1"
+  dependencies:
+    elliptic: "npm:^6.5.7"
+    node-addon-api: "npm:^5.0.0"
+    node-gyp: "npm:latest"
+    node-gyp-build: "npm:^4.2.0"
+  checksum: 10c0/ea977fcd3a21ee10439a546774d4f3f474f065a561fc2247f65cb2a64f09628732fd606c0a62316858abd7c07b41f5aa09c37773537f233590b4cf94d752dbe7
+  languageName: node
+  linkType: hard
+
 "semver@npm:^7.3.5":
   version: 7.7.1
   resolution: "semver@npm:7.7.1"
@@ -3409,6 +3742,13 @@ __metadata:
   dependencies:
     punycode: "npm:^2.1.0"
   checksum: 10c0/41525c2ccce86e3ef30af6fa5e1464e6d8bb4286a58ea8db09228f598889581ef62347153f6636cd41553dc41685bdfad0a9d032ef58df9fbb0792b3447d0f04
+  languageName: node
+  linkType: hard
+
+"tr46@npm:~0.0.3":
+  version: 0.0.3
+  resolution: "tr46@npm:0.0.3"
+  checksum: 10c0/047cb209a6b60c742f05c9d3ace8fa510bff609995c129a37ace03476a9b12db4dbf975e74600830ef0796e18882b2381fb5fb1f6b4f96b832c374de3ab91a11
   languageName: node
   linkType: hard
 
@@ -3752,10 +4092,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"webidl-conversions@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "webidl-conversions@npm:3.0.1"
+  checksum: 10c0/5612d5f3e54760a797052eb4927f0ddc01383550f542ccd33d5238cfd65aeed392a45ad38364970d0a0f4fea32e1f4d231b3d8dac4a3bdd385e5cf802ae097db
+  languageName: node
+  linkType: hard
+
 "webidl-conversions@npm:^4.0.2":
   version: 4.0.2
   resolution: "webidl-conversions@npm:4.0.2"
   checksum: 10c0/def5c5ac3479286dffcb604547628b2e6b46c5c5b8a8cfaa8c71dc3bafc85859bde5fbe89467ff861f571ab38987cf6ab3d6e7c80b39b999e50e803c12f3164f
+  languageName: node
+  linkType: hard
+
+"whatwg-url@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "whatwg-url@npm:5.0.0"
+  dependencies:
+    tr46: "npm:~0.0.3"
+    webidl-conversions: "npm:^3.0.0"
+  checksum: 10c0/1588bed84d10b72d5eec1d0faa0722ba1962f1821e7539c535558fb5398d223b0c50d8acab950b8c488b4ba69043fd833cc2697056b167d8ad46fac3995a55d5
   languageName: node
   linkType: hard
 
@@ -3852,5 +4209,12 @@ __metadata:
   version: 5.0.0
   resolution: "yallist@npm:5.0.0"
   checksum: 10c0/a499c81ce6d4a1d260d4ea0f6d49ab4da09681e32c3f0472dee16667ed69d01dae63a3b81745a24bd78476ec4fcf856114cb4896ace738e01da34b2c42235416
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.24.2":
+  version: 3.25.76
+  resolution: "zod@npm:3.25.76"
+  checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
   languageName: node
   linkType: hard

--- a/yarn.lock
+++ b/yarn.lock
@@ -652,7 +652,6 @@ __metadata:
     "@fastnear/borsh": "workspace:*"
     "@fastnear/borsh-schema": "workspace:*"
     "@fastnear/utils": "workspace:*"
-    "@near-js/transactions": "npm:*"
     "@noble/curves": "npm:*"
     rimraf: "npm:*"
     tsup: "npm:^8.3.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -652,6 +652,7 @@ __metadata:
     "@fastnear/borsh": "workspace:*"
     "@fastnear/borsh-schema": "workspace:*"
     "@fastnear/utils": "workspace:*"
+    "@near-js/transactions": "npm:*"
     "@noble/curves": "npm:*"
     rimraf: "npm:*"
     tsup: "npm:^8.3.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -622,10 +622,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fastnear/near-connect@npm:*, @fastnear/near-connect@npm:^0.12.1":
-  version: 0.12.1
-  resolution: "@fastnear/near-connect@npm:0.12.1"
-  checksum: 10c0/5c67f092234675f7049a89a16046d6ca5374bec0121d68e6f56f1ff4f2676f8ceb3e203be7bead9531567ebd04eadfda4c5f1d474432a610a58b0009f7370afd
+"@fastnear/near-connect@npm:*, @fastnear/near-connect@npm:^0.13.0":
+  version: 0.13.0
+  resolution: "@fastnear/near-connect@npm:0.13.0"
+  checksum: 10c0/c7b945125d874693730bdc87ffc1a64032dd733e16e611449389c2554ed001cc16614c0b56ee96d583555836ced87ba6b70354f6ab0929d02885f6fbf6dcf566
   languageName: node
   linkType: hard
 
@@ -2340,7 +2340,7 @@ __metadata:
   dependencies:
     "@esbuild-plugins/node-globals-polyfill": "npm:^0.2.3"
     "@esbuild-plugins/node-modules-polyfill": "npm:^0.2.2"
-    "@fastnear/near-connect": "npm:^0.12.1"
+    "@fastnear/near-connect": "npm:^0.13.0"
     "@near-js/transactions": "npm:^2.5.1"
     "@noble/curves": "npm:=2.0.1"
     "@noble/hashes": "npm:=2.0.1"


### PR DESCRIPTION
Adds the @fastnear/x402 workspace package and the timeout-aware wallet bridge support required for x402 v2 exact NEAR payments.\n\nRelease status:\n- Published all @fastnear workspaces at 1.5.0 on npm latest\n- @fastnear/x402@1.5.0 published and jsDelivr IIFE verified\n- near-connect 0.13.0 published and default Meteor manifest promoted after live QA\n- Live Meteor testnet settlement passed from mike.testnet: A611UdUXAGRLDTXvjbEZzmR6fuUgpuuDKfXpCkhtbiyw\n- Hosted schema-v5 agent assets are deployed on js.fastnear.com\n\nLocal gates run before publish:\n- yarn install --immutable\n- yarn type-check\n- yarn build\n- yarn vitest run\n- yarn test:formats\n- yarn test:packed on Node 20.19 and 22\n- yarn check:bundles\n- yarn check:agent\n- yarn smoke:x402:published 1.5.0\n\nRelease note: Intear wallet activation is intentionally deferred; Meteor Wallet is the tested production path for browser wallet x402 payments.