### PR TITLE
docs(agent): advertise hosted topic explainers in generated artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The monorepo now ships a low-level-first runtime plus a compact task catalog for
 - API key env var: `FASTNEAR_API_KEY`
 - Hosted recipe catalog: `https://js.fastnear.com/recipes.json`
 - Hosted terminal wrapper: `https://js.fastnear.com/agents.js`
+- Hosted topic explainers: `https://js.fastnear.com/x402.html` (x402 payments on NEAR), `https://js.fastnear.com/post-quantum.html` (Post-quantum ML-DSA-65 keys), `https://js.fastnear.com/retries.html` (Retries and bulk reads)
 - Free trial credits: `https://dashboard.fastnear.com`
 
 Set `FASTNEAR_API_KEY` before running the authenticated snippets.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -272,6 +272,7 @@ Indexed key-value history for exact keys, predecessor scans, and account-scoped 
 - API key env var: `FASTNEAR_API_KEY`
 - Hosted recipe catalog: `https://js.fastnear.com/recipes.json`
 - Hosted terminal wrapper: `https://js.fastnear.com/agents.js`
+- Hosted topic explainers: `https://js.fastnear.com/x402.html` (x402 payments on NEAR), `https://js.fastnear.com/post-quantum.html` (Post-quantum ML-DSA-65 keys), `https://js.fastnear.com/retries.html` (Retries and bulk reads)
 - Free trial credits: `https://dashboard.fastnear.com`
 
 Set `FASTNEAR_API_KEY` before running the authenticated snippets.

--- a/llms.txt
+++ b/llms.txt
@@ -92,6 +92,11 @@ Canonical machine-readable catalog:
 Canonical hosted agent wrapper:
 - https://js.fastnear.com/agents.js
 
+Hosted topic explainers:
+- https://js.fastnear.com/x402.html — x402 payments on NEAR
+- https://js.fastnear.com/post-quantum.html — Post-quantum ML-DSA-65 keys
+- https://js.fastnear.com/retries.html — Retries and bulk reads
+
 Wrapper source in repo:
 - recipes/near-node.mjs
 

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -194,6 +194,7 @@ EOF
 - API key env var: `FASTNEAR_API_KEY`
 - Hosted recipe catalog: `https://js.fastnear.com/recipes.json`
 - Hosted terminal wrapper: `https://js.fastnear.com/agents.js`
+- Hosted topic explainers: `https://js.fastnear.com/x402.html` (x402 payments on NEAR), `https://js.fastnear.com/post-quantum.html` (Post-quantum ML-DSA-65 keys), `https://js.fastnear.com/retries.html` (Retries and bulk reads)
 - Free trial credits: `https://dashboard.fastnear.com`
 
 Release contract:

--- a/recipes/index.json
+++ b/recipes/index.json
@@ -19,6 +19,23 @@
     "trialCreditsUrl": "https://dashboard.fastnear.com",
     "trialCreditsLabel": "dashboard.fastnear.com",
     "trialCreditsSummary": "Free trial credits are available at dashboard.fastnear.com.",
+    "hostedPages": [
+      {
+        "url": "https://js.fastnear.com/x402.html",
+        "topic": "x402 payments on NEAR",
+        "summary": "Integration map, payer quickstarts, constraints, and wallet-compatibility status for @fastnear/x402."
+      },
+      {
+        "url": "https://js.fastnear.com/post-quantum.html",
+        "topic": "Post-quantum ML-DSA-65 keys",
+        "summary": "Enrollment flow, key forms, wire sizes, and safety rules for @fastnear/ml-dsa-65."
+      },
+      {
+        "url": "https://js.fastnear.com/retries.html",
+        "topic": "Retries and bulk reads",
+        "summary": "Transient-failure retry defaults and the near.batch / near.view.many settled-results surface."
+      }
+    ],
     "discoveryOrder": [
       {
         "step": 1,

--- a/recipes/source.mjs
+++ b/recipes/source.mjs
@@ -531,6 +531,26 @@ export const supportSurface = {
   trialCreditsUrl: FASTNEAR_DASHBOARD_URL,
   trialCreditsLabel: "dashboard.fastnear.com",
   trialCreditsSummary: "Free trial credits are available at dashboard.fastnear.com.",
+  hostedPages: [
+    {
+      url: `${FASTNEAR_CDN_BASE}/x402.html`,
+      topic: "x402 payments on NEAR",
+      summary:
+        "Integration map, payer quickstarts, constraints, and wallet-compatibility status for @fastnear/x402.",
+    },
+    {
+      url: `${FASTNEAR_CDN_BASE}/post-quantum.html`,
+      topic: "Post-quantum ML-DSA-65 keys",
+      summary:
+        "Enrollment flow, key forms, wire sizes, and safety rules for @fastnear/ml-dsa-65.",
+    },
+    {
+      url: `${FASTNEAR_CDN_BASE}/retries.html`,
+      topic: "Retries and bulk reads",
+      summary:
+        "Transient-failure retry defaults and the near.batch / near.view.many settled-results surface.",
+    },
+  ],
   discoveryOrder: [
     {
       step: 1,

--- a/scripts/generate-agent-artifacts.mjs
+++ b/scripts/generate-agent-artifacts.mjs
@@ -266,6 +266,7 @@ function renderSupportSection() {
 - API key env var: ` + "`" + supportSurface.apiKeyEnvVar + "`" + `
 - Hosted recipe catalog: ` + "`" + supportSurface.hostedCatalogUrl + "`" + `
 - Hosted terminal wrapper: ` + "`" + supportSurface.hostedAgentEntry + "`" + `
+- Hosted topic explainers: ` + supportSurface.hostedPages.map((page) => "`" + page.url + "`" + " (" + page.topic + ")").join(", ") + `
 - Free trial credits: ` + "`" + supportSurface.trialCreditsUrl + "`" + `
 
 Set ` + "`" + supportSurface.apiKeyEnvVar + "`" + ` before running the authenticated snippets.
@@ -504,6 +505,7 @@ ${kvTerminalSnippet.code}
 - API key env var: ` + "`" + supportSurface.apiKeyEnvVar + "`" + `
 - Hosted recipe catalog: ` + "`" + supportSurface.hostedCatalogUrl + "`" + `
 - Hosted terminal wrapper: ` + "`" + supportSurface.hostedAgentEntry + "`" + `
+- Hosted topic explainers: ` + supportSurface.hostedPages.map((page) => "`" + page.url + "`" + " (" + page.topic + ")").join(", ") + `
 - Free trial credits: ` + "`" + supportSurface.trialCreditsUrl + "`" + `
 
 Release contract:
@@ -690,6 +692,9 @@ Canonical machine-readable catalog:
 Canonical hosted agent wrapper:
 - ${FASTNEAR_AGENT_ENTRY}
 
+Hosted topic explainers:
+${supportSurface.hostedPages.map((page) => `- ${page.url} — ${page.topic}`).join("\n")}
+
 Wrapper source in repo:
 - recipes/near-node.mjs
 
@@ -805,6 +810,7 @@ ${renderList(family.entrypoints.map((entrypoint) => `\`${entrypoint}\``))}
 - API key env var: ` + "`" + supportSurface.apiKeyEnvVar + "`" + `
 - Hosted recipe catalog: ` + "`" + supportSurface.hostedCatalogUrl + "`" + `
 - Hosted terminal wrapper: ` + "`" + supportSurface.hostedAgentEntry + "`" + `
+- Hosted topic explainers: ` + supportSurface.hostedPages.map((page) => "`" + page.url + "`" + " (" + page.topic + ")").join(", ") + `
 - Free trial credits: ` + "`" + supportSurface.trialCreditsUrl + "`" + `
 
 Set ` + "`" + supportSurface.apiKeyEnvVar + "`" + ` before running the authenticated snippets.


### PR DESCRIPTION
js.fastnear.com now hosts three human-readable, agent-friendly topic pages: `/x402.html` (x402 payments on NEAR), `/post-quantum.html` (ML-DSA-65 keys), and `/retries.html` (retries and bulk reads) — added in fastnear/fastnear-js-static-demo#6.

This PR makes them discoverable through the generated agent artifacts:

- `recipes/source.mjs`: adds `supportSurface.hostedPages` (`{ url, topic, summary }` per page), derived from `FASTNEAR_CDN_BASE`
- `generate-agent-artifacts.mjs`: renders them as a "Hosted topic explainers" list in `llms.txt` and as a bullet in every Access-and-chaining block (`llms-full.txt`, root README, api README)
- Artifacts regenerated with `yarn generate:agent`; `yarn check:agent` passes

**Pairs with fastnear/fastnear-js-static-demo#6** — the published-surface smoke (`smoke-published-agent-surfaces.mjs`) wants byte-identical hosted artifacts, so deploy both close together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6uCxbhXe3dfhtVqLZkGo5