### PR TITLE
fix: harden the funded intents smoke; log the first settled mainnet swap

### DIFF
--- a/packages/intents/MAINNET_QA.md
+++ b/packages/intents/MAINNET_QA.md
@@ -51,7 +51,7 @@ Record each release-gating run here:
 
 | Date | Package version | Account | Amount | Result | Notes |
 |------|-----------------|---------|--------|--------|-------|
-| —    | —               | —       | —      | —      | first entry pending a funded run |
+| 2026-07-22 | 1.6.0 | mike.near | 0.05 wNEAR → 0.093389 USDC | SUCCESS | intent `DBcSo8Cx7wqUF6QoeK4HpFXADX9V7M9RpbvDj2iG8Qoy`; deposit tx `8fWAQiaTKhRSx5fMhuUcGf8ZLs9t53fknNhVziTLKcY4`; settlement `6ZKK34vbT9gbbKr1ugYyQj9Qv7pmTpuVwHZW7P78rU8a`; keyless (0.2% fee); required storage-registering the deposit address on wrap.near first |
 
 ## Known live-surface caveats
 
@@ -61,3 +61,8 @@ Record each release-gating run here:
   2026-07-22 by the dry smoke); relay-path QA needs partner credentials.
 - Deposit addresses expire (`timeWhenInactive`) — the funded smoke commits
   its quote immediately before depositing.
+- NEAR-chain deposit addresses are fresh implicit accounts with NO storage
+  registration on the token contract — an unregistered `ft_transfer` reverts
+  on-chain (verified 2026-07-22). The smoke storage-registers the address
+  (~0.00125 NEAR) before transferring; integrators sending NEP-141 deposits
+  from NEAR must do the same.

--- a/scripts/smoke-intents-mainnet.mjs
+++ b/scripts/smoke-intents-mainnet.mjs
@@ -51,6 +51,33 @@ const oneClick = createOneClickClient({
 });
 const step = (label, detail) => console.log(`✓ ${label}${detail ? ` — ${detail}` : ""}`);
 
+// Unwrap a send_tx response, assert every receipt succeeded, return the hash.
+function assertTxSuccess(response, label) {
+  const outcome = response?.result ?? response;
+  const hash = outcome?.transaction?.hash;
+  const failures = [];
+  const topStatus = outcome?.status;
+  if (topStatus && typeof topStatus === "object" && "Failure" in topStatus) {
+    failures.push(topStatus.Failure);
+  }
+  for (const receipt of outcome?.receipts_outcome ?? []) {
+    const status = receipt?.outcome?.status;
+    if (status && typeof status === "object" && "Failure" in status) {
+      failures.push(status.Failure);
+    }
+  }
+  if (failures.length > 0) {
+    console.error(`✗ ${label} FAILED on-chain (tx ${hash ?? "unknown"}):`);
+    console.error(JSON.stringify(failures, null, 2));
+    process.exit(1);
+  }
+  if (!hash) {
+    console.error(`✗ ${label}: could not read transaction hash from the RPC response`);
+    process.exit(1);
+  }
+  return hash;
+}
+
 // --- Preflight (always) ----------------------------------------------------
 
 const publicKey = publicKeyFromPrivate(PRIVATE_KEY);
@@ -123,7 +150,7 @@ if (wnearBalance < BigInt(AMOUNT)) {
     waitUntil: "FINAL",
     network: "mainnet",
   });
-  step("wrapped NEAR", wrapResult?.transaction?.hash ?? "(submitted)");
+  step("wrapped NEAR", assertTxSuccess(wrapResult, "near_deposit"));
 }
 
 const committed = await oneClick.quote({
@@ -137,6 +164,42 @@ if (!depositAddress) {
   process.exit(1);
 }
 step("committed quote", `depositAddress ${depositAddress}`);
+
+// A fresh implicit deposit address has no storage on wrap.near — an
+// unregistered receiver makes ft_transfer revert. Register it first.
+const storage = await view({
+  contractId: WNEAR,
+  methodName: "storage_balance_of",
+  args: { account_id: depositAddress },
+  network: "mainnet",
+});
+if (storage == null) {
+  const bounds = await view({
+    contractId: WNEAR,
+    methodName: "storage_balance_bounds",
+    args: {},
+    network: "mainnet",
+  });
+  const registerResult = await sendTx({
+    signerId: ACCOUNT_ID,
+    signer: signerFromPrivateKey(PRIVATE_KEY),
+    receiverId: WNEAR,
+    actions: [
+      actions.functionCall({
+        methodName: "storage_deposit",
+        args: { account_id: depositAddress, registration_only: true },
+        gas: FT_TRANSFER_GAS,
+        deposit: String(bounds?.min ?? "1250000000000000000000"),
+      }),
+    ],
+    waitUntil: "FINAL",
+    network: "mainnet",
+  });
+  step(
+    "deposit address storage-registered on wrap.near",
+    assertTxSuccess(registerResult, "storage_deposit"),
+  );
+}
 
 const transferResult = await sendTx({
   signerId: ACCOUNT_ID,
@@ -153,13 +216,11 @@ const transferResult = await sendTx({
   waitUntil: "FINAL",
   network: "mainnet",
 });
-const depositTxHash = transferResult?.transaction?.hash;
-step("deposit sent", depositTxHash ?? "(submitted)");
+const depositTxHash = assertTxSuccess(transferResult, "ft_transfer to deposit address");
+step("deposit sent", depositTxHash);
 
-if (depositTxHash) {
-  await oneClick.submitDeposit({ txHash: depositTxHash, depositAddress });
-  step("deposit tx reported to 1Click");
-}
+await oneClick.submitDeposit({ txHash: depositTxHash, depositAddress });
+step("deposit tx reported to 1Click");
 
 const deadline = Date.now() + POLL_TIMEOUT_MS;
 let finalStatus = null;


### PR DESCRIPTION
The first funded run of `scripts/smoke-intents-mainnet.mjs` (post-1.6.0) exposed three bugs — all fixed and then **verified by a real settled swap on mainnet**:

## Bugs found by the live run
1. **Missing storage registration**: 1Click's NEAR-chain deposit addresses are fresh implicit accounts with no storage on wrap.near, so the `ft_transfer` deposit **reverted on-chain** while the script printed ✓. The smoke now checks `storage_balance_of` and registers the address (~0.00125 NEAR) first.
2. **No outcome checking**: submission was treated as success. New `assertTxSuccess` walks every receipt outcome and aborts with the failure JSON.
3. **Wrong hash path**: tx hashes live at `.result.transaction.hash`; the old path printed "(submitted)" and silently skipped the `POST /v0/deposit/submit` accelerator.

## Proof (inaugural MAINNET_QA.md entry)
2026-07-22 · 1.6.0 · mike.near · **0.05 wNEAR → 0.093389 USDC · SUCCESS**
- intent `DBcSo8Cx7wqUF6QoeK4HpFXADX9V7M9RpbvDj2iG8Qoy`
- deposit `8fWAQiaTKhRSx5fMhuUcGf8ZLs9t53fknNhVziTLKcY4` (mike.near → wrap.near ✅)
- settlement `6ZKK34vbT9gbbKr1ugYyQj9Qv7pmTpuVwHZW7P78rU8a` (intents.near execute_intents ✅)
- USDC receipt confirmed by on-chain `ft_balance_of`

Flow after the fix: PENDING_DEPOSIT → PROCESSING → SUCCESS in ~20s.

Also adds the storage-registration caveat to the QA runbook for integrators sending NEP-141 deposits from NEAR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6uCxbhXe3dfhtVqLZkGo5