### PR TITLE
fix: export advertised wallet network helpers; repair three recipe snippets

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1400,15 +1400,16 @@ Example inputs:
 node -e "$(curl -fsSL https://js.fastnear.com/agents.js)" <<'EOF'
 const block = await near.neardata.lastBlockFinal();
 
+// shard.chunk is null when a shard missed this block — guard before reading.
 near.print({
   height: block.block.header.height,
   timestamp_nanosec: block.block.header.timestamp_nanosec,
   txs_per_shard: block.shards.map((shard) => ({
     shard_id: shard.shard_id,
-    tx_count: shard.chunk.transactions.length,
+    tx_count: shard.chunk?.transactions.length ?? 0,
   })),
   total_txs: block.shards.reduce(
-    (count, shard) => count + shard.chunk.transactions.length,
+    (count, shard) => count + (shard.chunk?.transactions.length ?? 0),
     0
   ),
 });
@@ -1432,15 +1433,16 @@ curl -sSL "https://mainnet.neardata.xyz/v0/last_block/final?apiKey=$FASTNEAR_API
 ```js
 const block = await near.neardata.lastBlockFinal();
 
+// shard.chunk is null when a shard missed this block — guard before reading.
 near.print({
   height: block.block.header.height,
   timestamp_nanosec: block.block.header.timestamp_nanosec,
   txs_per_shard: block.shards.map((shard) => ({
     shard_id: shard.shard_id,
-    tx_count: shard.chunk.transactions.length,
+    tx_count: shard.chunk?.transactions.length ?? 0,
   })),
   total_txs: block.shards.reduce(
-    (count, shard) => count + shard.chunk.transactions.length,
+    (count, shard) => count + (shard.chunk?.transactions.length ?? 0),
     0
   ),
 });
@@ -1455,15 +1457,16 @@ near.config({ apiKey: process.env.FASTNEAR_API_KEY || undefined });
 
 const block = await near.neardata.lastBlockFinal();
 
+// shard.chunk is null when a shard missed this block — guard before reading.
 near.print({
   height: block.block.header.height,
   timestamp_nanosec: block.block.header.timestamp_nanosec,
   txs_per_shard: block.shards.map((shard) => ({
     shard_id: shard.shard_id,
-    tx_count: shard.chunk.transactions.length,
+    tx_count: shard.chunk?.transactions.length ?? 0,
   })),
   total_txs: block.shards.reduce(
-    (count, shard) => count + shard.chunk.transactions.length,
+    (count, shard) => count + (shard.chunk?.transactions.length ?? 0),
     0
   ),
 });
@@ -2581,11 +2584,11 @@ near.print({
 - ID: `nft-inventory`
 - API: `near.nft.inventory`
 - Service: `api`
-- Returns: `{ tokens: Array<{ contract_id: string; tokens?: Array<{ token_id: string }> }> }`
+- Returns: `{ tokens: Array<{ contract_id: string; last_update_block_height: number | null }> }`
 - Network: `mainnet`
 - Auth: `bearer`
 - Summary: Discover every NEP-171 contract the account holds tokens under via the FastNear indexer.
-- Output keys: `contract_count`, `total_tokens`, `preview[].contract_id`, `preview[].sample_token_ids`
+- Output keys: `contract_count`, `preview[].contract_id`, `preview[].last_update_block_height`
 - Pagination: none; request fields: none; response fields: none; filters must stay stable: no
 
 Choose this when:
@@ -2596,7 +2599,7 @@ Choose this when:
 Response notes:
 
 - near.nft.inventory hits the FastNear indexer — set near.config({ apiKey }) to avoid the public rate limit.
-- One row per NFT contract the account holds; the embedded token list is best-effort and may need follow-up calls for full metadata.
+- One row per NFT contract the account holds — contract ids only, no per-token ids; follow up with nft-for-owner per contract for token details.
 
 Follow-ups:
 
@@ -2627,15 +2630,13 @@ const inventory = await near.nft.inventory({
   accountId: "root.near",
 });
 
+// The inventory endpoint returns contract-level rows only (no per-token
+// ids) — use the nft-for-owner recipe to list tokens on one contract.
 near.print({
   contract_count: inventory.tokens.length,
-  total_tokens: inventory.tokens.reduce(
-    (sum, c) => sum + (c.tokens?.length ?? 0),
-    0
-  ),
   preview: inventory.tokens.slice(0, 3).map((entry) => ({
     contract_id: entry.contract_id,
-    sample_token_ids: (entry.tokens || []).slice(0, 3).map((t) => t.token_id),
+    last_update_block_height: entry.last_update_block_height,
   })),
 });
 EOF
@@ -2661,15 +2662,13 @@ const inventory = await near.nft.inventory({
   accountId: "root.near",
 });
 
+// The inventory endpoint returns contract-level rows only (no per-token
+// ids) — use the nft-for-owner recipe to list tokens on one contract.
 near.print({
   contract_count: inventory.tokens.length,
-  total_tokens: inventory.tokens.reduce(
-    (sum, c) => sum + (c.tokens?.length ?? 0),
-    0
-  ),
   preview: inventory.tokens.slice(0, 3).map((entry) => ({
     contract_id: entry.contract_id,
-    sample_token_ids: (entry.tokens || []).slice(0, 3).map((t) => t.token_id),
+    last_update_block_height: entry.last_update_block_height,
   })),
 });
 ```
@@ -2686,15 +2685,13 @@ const inventory = await near.nft.inventory({
   accountId: "root.near",
 });
 
+// The inventory endpoint returns contract-level rows only (no per-token
+// ids) — use the nft-for-owner recipe to list tokens on one contract.
 near.print({
   contract_count: inventory.tokens.length,
-  total_tokens: inventory.tokens.reduce(
-    (sum, c) => sum + (c.tokens?.length ?? 0),
-    0
-  ),
   preview: inventory.tokens.slice(0, 3).map((entry) => ({
     contract_id: entry.contract_id,
-    sample_token_ids: (entry.tokens || []).slice(0, 3).map((t) => t.token_id),
+    last_update_block_height: entry.last_update_block_height,
   })),
 });
 ```
@@ -2755,11 +2752,14 @@ const past = await near.queryAccount({
   useArchival: true,
 });
 
+// near.query* returns the raw JSON-RPC envelope — the data lives in .result.
+const acct = past.result;
+
 near.print({
-  amount: past.amount,
-  storage_usage: past.storage_usage,
-  block_hash: past.block_hash,
-  block_height: past.block_height,
+  amount: acct.amount,
+  storage_usage: acct.storage_usage,
+  block_hash: acct.block_hash,
+  block_height: acct.block_height,
 });
 EOF
 ```
@@ -2789,11 +2789,14 @@ const past = await near.queryAccount({
   useArchival: true,
 });
 
+// near.query* returns the raw JSON-RPC envelope — the data lives in .result.
+const acct = past.result;
+
 near.print({
-  amount: past.amount,
-  storage_usage: past.storage_usage,
-  block_hash: past.block_hash,
-  block_height: past.block_height,
+  amount: acct.amount,
+  storage_usage: acct.storage_usage,
+  block_hash: acct.block_hash,
+  block_height: acct.block_height,
 });
 ```
 
@@ -2813,11 +2816,14 @@ const past = await near.queryAccount({
   useArchival: true,
 });
 
+// near.query* returns the raw JSON-RPC envelope — the data lives in .result.
+const acct = past.result;
+
 near.print({
-  amount: past.amount,
-  storage_usage: past.storage_usage,
-  block_hash: past.block_hash,
-  block_height: past.block_height,
+  amount: acct.amount,
+  storage_usage: acct.storage_usage,
+  block_hash: acct.block_hash,
+  block_height: acct.block_height,
 });
 ```
 

--- a/llms.txt
+++ b/llms.txt
@@ -159,7 +159,7 @@ Recipe index:
 - ft-metadata: What does this NEP-141 token call itself? (rpc, { name: string; symbol: string; decimals: number; icon?: string; reference?: string; reference_hash?: string }, none, mainnet)
 - ft-inventory: Which fungible tokens does this account hold? (api, { tokens: Array<{ contract_id: string; balance: string; last_update_block_height?: number }> }, bearer, mainnet)
 - nft-for-owner: Which NFTs does this account own on this contract? (rpc, Array<{ token_id: string; owner_id: string; metadata?: { title?: string; media?: string; description?: string } }>, none, mainnet)
-- nft-inventory: Which NFT contracts does this account hold tokens on? (api, { tokens: Array<{ contract_id: string; tokens?: Array<{ token_id: string }> }> }, bearer, mainnet)
+- nft-inventory: Which NFT contracts does this account hold tokens on? (api, { tokens: Array<{ contract_id: string; last_update_block_height: number | null }> }, bearer, mainnet)
 - archival-snapshot: What did this account look like at a specific block? (rpc, RpcViewAccountResponse, none, mainnet)
 - connect-testnet: How do I open a testnet wallet session alongside mainnet? (wallet, { accountId: string; network?: "mainnet" | "testnet" } | undefined, wallet, testnet)
 - function-call-testnet: How do I send a function call on testnet without losing my mainnet session? (wallet, { outcomes?: any[] } | { rejected: true } | undefined, wallet, testnet)

--- a/packages/wallet/src/index.ts
+++ b/packages/wallet/src/index.ts
@@ -17,7 +17,9 @@ export {
   removeDebugWallet,
   switchNetwork,
   addFunctionCallKey,
-  signDelegateActions
+  signDelegateActions,
+  connectedNetworks,
+  getActiveNetwork
 } from "./connector.js";
 
 export type {

--- a/recipes/index.json
+++ b/recipes/index.json
@@ -797,7 +797,7 @@
           "environment": "terminal",
           "language": "bash",
           "runnable": true,
-          "code": "# Assumes FASTNEAR_API_KEY is already set in your shell.\nnode -e \"$(curl -fsSL https://js.fastnear.com/agents.js)\" <<'EOF'\nconst block = await near.neardata.lastBlockFinal();\n\nnear.print({\n  height: block.block.header.height,\n  timestamp_nanosec: block.block.header.timestamp_nanosec,\n  txs_per_shard: block.shards.map((shard) => ({\n    shard_id: shard.shard_id,\n    tx_count: shard.chunk.transactions.length,\n  })),\n  total_txs: block.shards.reduce(\n    (count, shard) => count + shard.chunk.transactions.length,\n    0\n  ),\n});\nEOF"
+          "code": "# Assumes FASTNEAR_API_KEY is already set in your shell.\nnode -e \"$(curl -fsSL https://js.fastnear.com/agents.js)\" <<'EOF'\nconst block = await near.neardata.lastBlockFinal();\n\n// shard.chunk is null when a shard missed this block — guard before reading.\nnear.print({\n  height: block.block.header.height,\n  timestamp_nanosec: block.block.header.timestamp_nanosec,\n  txs_per_shard: block.shards.map((shard) => ({\n    shard_id: shard.shard_id,\n    tx_count: shard.chunk?.transactions.length ?? 0,\n  })),\n  total_txs: block.shards.reduce(\n    (count, shard) => count + (shard.chunk?.transactions.length ?? 0),\n    0\n  ),\n});\nEOF"
         },
         {
           "id": "curl-jq",
@@ -813,7 +813,7 @@
           "environment": "browserGlobal",
           "language": "js",
           "runnable": true,
-          "code": "const block = await near.neardata.lastBlockFinal();\n\nnear.print({\n  height: block.block.header.height,\n  timestamp_nanosec: block.block.header.timestamp_nanosec,\n  txs_per_shard: block.shards.map((shard) => ({\n    shard_id: shard.shard_id,\n    tx_count: shard.chunk.transactions.length,\n  })),\n  total_txs: block.shards.reduce(\n    (count, shard) => count + shard.chunk.transactions.length,\n    0\n  ),\n});"
+          "code": "const block = await near.neardata.lastBlockFinal();\n\n// shard.chunk is null when a shard missed this block — guard before reading.\nnear.print({\n  height: block.block.header.height,\n  timestamp_nanosec: block.block.header.timestamp_nanosec,\n  txs_per_shard: block.shards.map((shard) => ({\n    shard_id: shard.shard_id,\n    tx_count: shard.chunk?.transactions.length ?? 0,\n  })),\n  total_txs: block.shards.reduce(\n    (count, shard) => count + (shard.chunk?.transactions.length ?? 0),\n    0\n  ),\n});"
         },
         {
           "id": "esm",
@@ -821,7 +821,7 @@
           "environment": "esm",
           "language": "js",
           "runnable": true,
-          "code": "import * as near from \"@fastnear/api\";\n\nnear.config({ apiKey: process.env.FASTNEAR_API_KEY || undefined });\n\nconst block = await near.neardata.lastBlockFinal();\n\nnear.print({\n  height: block.block.header.height,\n  timestamp_nanosec: block.block.header.timestamp_nanosec,\n  txs_per_shard: block.shards.map((shard) => ({\n    shard_id: shard.shard_id,\n    tx_count: shard.chunk.transactions.length,\n  })),\n  total_txs: block.shards.reduce(\n    (count, shard) => count + shard.chunk.transactions.length,\n    0\n  ),\n});"
+          "code": "import * as near from \"@fastnear/api\";\n\nnear.config({ apiKey: process.env.FASTNEAR_API_KEY || undefined });\n\nconst block = await near.neardata.lastBlockFinal();\n\n// shard.chunk is null when a shard missed this block — guard before reading.\nnear.print({\n  height: block.block.header.height,\n  timestamp_nanosec: block.block.header.timestamp_nanosec,\n  txs_per_shard: block.shards.map((shard) => ({\n    shard_id: shard.shard_id,\n    tx_count: shard.chunk?.transactions.length ?? 0,\n  })),\n  total_txs: block.shards.reduce(\n    (count, shard) => count + (shard.chunk?.transactions.length ?? 0),\n    0\n  ),\n});"
         }
       ],
       "service": "neardata",
@@ -1625,7 +1625,7 @@
           "environment": "terminal",
           "language": "bash",
           "runnable": true,
-          "code": "# Assumes FASTNEAR_API_KEY is already set in your shell.\nnode -e \"$(curl -fsSL https://js.fastnear.com/agents.js)\" <<'EOF'\n// Tip: `near.config({ apiKey: \"<your_key>\" })` raises rate limits.\nconst inventory = await near.nft.inventory({\n  accountId: \"root.near\",\n});\n\nnear.print({\n  contract_count: inventory.tokens.length,\n  total_tokens: inventory.tokens.reduce(\n    (sum, c) => sum + (c.tokens?.length ?? 0),\n    0\n  ),\n  preview: inventory.tokens.slice(0, 3).map((entry) => ({\n    contract_id: entry.contract_id,\n    sample_token_ids: (entry.tokens || []).slice(0, 3).map((t) => t.token_id),\n  })),\n});\nEOF"
+          "code": "# Assumes FASTNEAR_API_KEY is already set in your shell.\nnode -e \"$(curl -fsSL https://js.fastnear.com/agents.js)\" <<'EOF'\n// Tip: `near.config({ apiKey: \"<your_key>\" })` raises rate limits.\nconst inventory = await near.nft.inventory({\n  accountId: \"root.near\",\n});\n\n// The inventory endpoint returns contract-level rows only (no per-token\n// ids) — use the nft-for-owner recipe to list tokens on one contract.\nnear.print({\n  contract_count: inventory.tokens.length,\n  preview: inventory.tokens.slice(0, 3).map((entry) => ({\n    contract_id: entry.contract_id,\n    last_update_block_height: entry.last_update_block_height,\n  })),\n});\nEOF"
         },
         {
           "id": "curl-jq",
@@ -1641,7 +1641,7 @@
           "environment": "browserGlobal",
           "language": "js",
           "runnable": true,
-          "code": "// Tip: `near.config({ apiKey: \"<your_key>\" })` raises rate limits.\nconst inventory = await near.nft.inventory({\n  accountId: \"root.near\",\n});\n\nnear.print({\n  contract_count: inventory.tokens.length,\n  total_tokens: inventory.tokens.reduce(\n    (sum, c) => sum + (c.tokens?.length ?? 0),\n    0\n  ),\n  preview: inventory.tokens.slice(0, 3).map((entry) => ({\n    contract_id: entry.contract_id,\n    sample_token_ids: (entry.tokens || []).slice(0, 3).map((t) => t.token_id),\n  })),\n});"
+          "code": "// Tip: `near.config({ apiKey: \"<your_key>\" })` raises rate limits.\nconst inventory = await near.nft.inventory({\n  accountId: \"root.near\",\n});\n\n// The inventory endpoint returns contract-level rows only (no per-token\n// ids) — use the nft-for-owner recipe to list tokens on one contract.\nnear.print({\n  contract_count: inventory.tokens.length,\n  preview: inventory.tokens.slice(0, 3).map((entry) => ({\n    contract_id: entry.contract_id,\n    last_update_block_height: entry.last_update_block_height,\n  })),\n});"
         },
         {
           "id": "esm",
@@ -1649,20 +1649,19 @@
           "environment": "esm",
           "language": "js",
           "runnable": true,
-          "code": "import * as near from \"@fastnear/api\";\n\nnear.config({ apiKey: process.env.FASTNEAR_API_KEY || undefined });\n\n// Tip: `near.config({ apiKey: \"<your_key>\" })` raises rate limits.\nconst inventory = await near.nft.inventory({\n  accountId: \"root.near\",\n});\n\nnear.print({\n  contract_count: inventory.tokens.length,\n  total_tokens: inventory.tokens.reduce(\n    (sum, c) => sum + (c.tokens?.length ?? 0),\n    0\n  ),\n  preview: inventory.tokens.slice(0, 3).map((entry) => ({\n    contract_id: entry.contract_id,\n    sample_token_ids: (entry.tokens || []).slice(0, 3).map((t) => t.token_id),\n  })),\n});"
+          "code": "import * as near from \"@fastnear/api\";\n\nnear.config({ apiKey: process.env.FASTNEAR_API_KEY || undefined });\n\n// Tip: `near.config({ apiKey: \"<your_key>\" })` raises rate limits.\nconst inventory = await near.nft.inventory({\n  accountId: \"root.near\",\n});\n\n// The inventory endpoint returns contract-level rows only (no per-token\n// ids) — use the nft-for-owner recipe to list tokens on one contract.\nnear.print({\n  contract_count: inventory.tokens.length,\n  preview: inventory.tokens.slice(0, 3).map((entry) => ({\n    contract_id: entry.contract_id,\n    last_update_block_height: entry.last_update_block_height,\n  })),\n});"
         }
       ],
       "service": "api",
-      "returns": "{ tokens: Array<{ contract_id: string; tokens?: Array<{ token_id: string }> }> }",
+      "returns": "{ tokens: Array<{ contract_id: string; last_update_block_height: number | null }> }",
       "outputKeys": [
         "contract_count",
-        "total_tokens",
         "preview[].contract_id",
-        "preview[].sample_token_ids"
+        "preview[].last_update_block_height"
       ],
       "responseNotes": [
         "near.nft.inventory hits the FastNear indexer — set near.config({ apiKey }) to avoid the public rate limit.",
-        "One row per NFT contract the account holds; the embedded token list is best-effort and may need follow-up calls for full metadata."
+        "One row per NFT contract the account holds — contract ids only, no per-token ids; follow up with nft-for-owner per contract for token details."
       ],
       "chooseWhen": [
         "Choose this when the question is 'what NFT contracts does this account hold tokens on?'.",
@@ -1703,7 +1702,7 @@
           "environment": "terminal",
           "language": "bash",
           "runnable": true,
-          "code": "# Assumes FASTNEAR_API_KEY is already set in your shell.\nnode -e \"$(curl -fsSL https://js.fastnear.com/agents.js)\" <<'EOF'\n// Reads canonical account state at a specific historical block via the\n// archival RPC. Add useArchival to any view/query when blockId predates\n// the regular RPC's retention window (~5 epochs / a few days).\nconst past = await near.queryAccount({\n  accountId: \"root.near\",\n  blockId: 100_000_000,\n  useArchival: true,\n});\n\nnear.print({\n  amount: past.amount,\n  storage_usage: past.storage_usage,\n  block_hash: past.block_hash,\n  block_height: past.block_height,\n});\nEOF"
+          "code": "# Assumes FASTNEAR_API_KEY is already set in your shell.\nnode -e \"$(curl -fsSL https://js.fastnear.com/agents.js)\" <<'EOF'\n// Reads canonical account state at a specific historical block via the\n// archival RPC. Add useArchival to any view/query when blockId predates\n// the regular RPC's retention window (~5 epochs / a few days).\nconst past = await near.queryAccount({\n  accountId: \"root.near\",\n  blockId: 100_000_000,\n  useArchival: true,\n});\n\n// near.query* returns the raw JSON-RPC envelope — the data lives in .result.\nconst acct = past.result;\n\nnear.print({\n  amount: acct.amount,\n  storage_usage: acct.storage_usage,\n  block_hash: acct.block_hash,\n  block_height: acct.block_height,\n});\nEOF"
         },
         {
           "id": "curl-jq",
@@ -1719,7 +1718,7 @@
           "environment": "browserGlobal",
           "language": "js",
           "runnable": true,
-          "code": "// Reads canonical account state at a specific historical block via the\n// archival RPC. Add useArchival to any view/query when blockId predates\n// the regular RPC's retention window (~5 epochs / a few days).\nconst past = await near.queryAccount({\n  accountId: \"root.near\",\n  blockId: 100_000_000,\n  useArchival: true,\n});\n\nnear.print({\n  amount: past.amount,\n  storage_usage: past.storage_usage,\n  block_hash: past.block_hash,\n  block_height: past.block_height,\n});"
+          "code": "// Reads canonical account state at a specific historical block via the\n// archival RPC. Add useArchival to any view/query when blockId predates\n// the regular RPC's retention window (~5 epochs / a few days).\nconst past = await near.queryAccount({\n  accountId: \"root.near\",\n  blockId: 100_000_000,\n  useArchival: true,\n});\n\n// near.query* returns the raw JSON-RPC envelope — the data lives in .result.\nconst acct = past.result;\n\nnear.print({\n  amount: acct.amount,\n  storage_usage: acct.storage_usage,\n  block_hash: acct.block_hash,\n  block_height: acct.block_height,\n});"
         },
         {
           "id": "esm",
@@ -1727,7 +1726,7 @@
           "environment": "esm",
           "language": "js",
           "runnable": true,
-          "code": "import * as near from \"@fastnear/api\";\n\nnear.config({ apiKey: process.env.FASTNEAR_API_KEY || undefined });\n\n// Reads canonical account state at a specific historical block via the\n// archival RPC. Add useArchival to any view/query when blockId predates\n// the regular RPC's retention window (~5 epochs / a few days).\nconst past = await near.queryAccount({\n  accountId: \"root.near\",\n  blockId: 100_000_000,\n  useArchival: true,\n});\n\nnear.print({\n  amount: past.amount,\n  storage_usage: past.storage_usage,\n  block_hash: past.block_hash,\n  block_height: past.block_height,\n});"
+          "code": "import * as near from \"@fastnear/api\";\n\nnear.config({ apiKey: process.env.FASTNEAR_API_KEY || undefined });\n\n// Reads canonical account state at a specific historical block via the\n// archival RPC. Add useArchival to any view/query when blockId predates\n// the regular RPC's retention window (~5 epochs / a few days).\nconst past = await near.queryAccount({\n  accountId: \"root.near\",\n  blockId: 100_000_000,\n  useArchival: true,\n});\n\n// near.query* returns the raw JSON-RPC envelope — the data lives in .result.\nconst acct = past.result;\n\nnear.print({\n  amount: acct.amount,\n  storage_usage: acct.storage_usage,\n  block_hash: acct.block_hash,\n  block_height: acct.block_height,\n});"
         }
       ],
       "service": "rpc",

--- a/recipes/source.mjs
+++ b/recipes/source.mjs
@@ -307,15 +307,16 @@ near.print({
 
   lastBlockFinal: `const block = await near.neardata.lastBlockFinal();
 
+// shard.chunk is null when a shard missed this block — guard before reading.
 near.print({
   height: block.block.header.height,
   timestamp_nanosec: block.block.header.timestamp_nanosec,
   txs_per_shard: block.shards.map((shard) => ({
     shard_id: shard.shard_id,
-    tx_count: shard.chunk.transactions.length,
+    tx_count: shard.chunk?.transactions.length ?? 0,
   })),
   total_txs: block.shards.reduce(
-    (count, shard) => count + shard.chunk.transactions.length,
+    (count, shard) => count + (shard.chunk?.transactions.length ?? 0),
     0
   ),
 });`,
@@ -459,15 +460,13 @@ const inventory = await near.nft.inventory({
   accountId: "root.near",
 });
 
+// The inventory endpoint returns contract-level rows only (no per-token
+// ids) — use the nft-for-owner recipe to list tokens on one contract.
 near.print({
   contract_count: inventory.tokens.length,
-  total_tokens: inventory.tokens.reduce(
-    (sum, c) => sum + (c.tokens?.length ?? 0),
-    0
-  ),
   preview: inventory.tokens.slice(0, 3).map((entry) => ({
     contract_id: entry.contract_id,
-    sample_token_ids: (entry.tokens || []).slice(0, 3).map((t) => t.token_id),
+    last_update_block_height: entry.last_update_block_height,
   })),
 });`,
 
@@ -480,11 +479,14 @@ const past = await near.queryAccount({
   useArchival: true,
 });
 
+// near.query* returns the raw JSON-RPC envelope — the data lives in .result.
+const acct = past.result;
+
 near.print({
-  amount: past.amount,
-  storage_usage: past.storage_usage,
-  block_hash: past.block_hash,
-  block_height: past.block_height,
+  amount: acct.amount,
+  storage_usage: acct.storage_usage,
+  block_hash: acct.block_hash,
+  block_height: acct.block_height,
 });`,
 
   connectTestnet: `// near.recipes.connect honors a per-call network override
@@ -1588,11 +1590,11 @@ export const recipeCatalog = [
     }),
   }, {
     service: "api",
-    returns: "{ tokens: Array<{ contract_id: string; tokens?: Array<{ token_id: string }> }> }",
-    outputKeys: ["contract_count", "total_tokens", "preview[].contract_id", "preview[].sample_token_ids"],
+    returns: "{ tokens: Array<{ contract_id: string; last_update_block_height: number | null }> }",
+    outputKeys: ["contract_count", "preview[].contract_id", "preview[].last_update_block_height"],
     responseNotes: [
       "near.nft.inventory hits the FastNear indexer — set near.config({ apiKey }) to avoid the public rate limit.",
-      "One row per NFT contract the account holds; the embedded token list is best-effort and may need follow-up calls for full metadata.",
+      "One row per NFT contract the account holds — contract ids only, no per-token ids; follow up with nft-for-owner per contract for token details.",
     ],
     chooseWhen: [
       "Choose this when the question is 'what NFT contracts does this account hold tokens on?'.",


### PR DESCRIPTION
Part of the 2026-07-22 fresh-eyes review of js.fastnear.com (842 automated checks against the published 1.6.0 packages + hosted artifacts). This PR makes the agent catalog's claims true again:

## Wallet barrel (`packages/wallet/src/index.ts`)
`connectedNetworks()` and `getActiveNetwork()` exist in `connector.ts` but were never exported from the package. The hosted `connect-testnet` recipe and llms.txt advertise `nearWallet.connectedNetworks()` — against published 1.6.0 it throws. Both are now exported (verified in CJS/ESM/IIFE builds).

**Publish note:** the published recipe stays broken until a patch release ships this. Proposal: `yarn workspaces foreach --all version 1.6.1` as the release commit — which would also (a) get the version bump *committed* this time (main still reads 1.5.0 with no v1.6.0 tag; yesterday's publish predates the last merge), and (b) pick up the `export type { x402Client }` fix already on main that 1.6.0's d.ts missed.

## Recipe snippets (`recipes/source.mjs` + regenerated artifacts)
All three verified failing against live endpoints as-written, and passing after the fix:

- **archival-snapshot** — read fields off the raw JSON-RPC envelope; printed `undefined` for every key. Now unwraps `.result` (matching llms.txt's own "Result shapes" section).
- **last-block-final** — `shard.chunk.transactions.length` throws a TypeError whenever the final block has a missed chunk (`chunk: null`). Now guarded; reproduced live before fixing.
- **nft-inventory** — computed `total_tokens`/`sample_token_ids` from a per-token array the endpoint never returns (contract-level rows only) — always printed `0`/empty. Now prints `contract_id` + `last_update_block_height`, and the declared return type matches the live response.

## Verification
- `yarn build`, `yarn vitest run` (416 passed), `yarn check:agent`, snippet smoke, bundle budgets — all green
- Fixed snippets executed verbatim against live mainnet endpoints
- Companion PR: fastnear/fastnear-js-static-demo (site fixes + synced artifacts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6uCxbhXe3dfhtVqLZkGo5