### PR TITLE
fix(x402): make the advertised x402Client export a real runtime value

### DIFF
--- a/packages/x402/src/index.test.ts
+++ b/packages/x402/src/index.test.ts
@@ -201,6 +201,11 @@ describe("createFastNearWalletSigner", () => {
 });
 
 describe("x402 client and fetch helpers", () => {
+  it("re-exports x402Client as a real runtime value (the d.ts advertises it)", async () => {
+    const barrel = await import("./index.js");
+    expect(typeof barrel.x402Client).toBe("function");
+  });
+
   it("creates a client registered for NEAR exact", async () => {
     const createSignedDelegateAction = vi.fn(async () => encodedSignedDelegate);
     const client = createNearX402Client({ signer: { createSignedDelegateAction } });

--- a/packages/x402/src/index.ts
+++ b/packages/x402/src/index.ts
@@ -208,4 +208,7 @@ export function createNearPaymentFetch({
 }
 
 export type { ClientNearSigner } from "@x402/near";
-export type { x402Client } from "@x402/core/client";
+// Value re-export, not `export type`: the dts bundler drops the `type`
+// keyword, so the published d.ts advertises a runtime export either way —
+// make it real (the class is a runtime dependency already imported above).
+export { x402Client } from "@x402/core/client";


### PR DESCRIPTION
Follow-up from the site review: `export type { x402Client }` in source gets its `type` keyword dropped by the dts bundler, so published d.ts (1.6.0 **and** 1.6.1) advertises `import { x402Client } from "@fastnear/x402"` — which type-checks and then throws at runtime.

Since `@x402/core` is a runtime dependency we already instantiate internally, the honest one-liner is a real value re-export. Added a barrel test so it can't silently regress.

- 417 tests pass, bundle budgets green
- Verified in the built package: d.ts `export { x402Client }` + `typeof === "function"` at runtime
- No urgency: nothing on the site or catalog references this import; it rides with the next publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6uCxbhXe3dfhtVqLZkGo5