### PR TITLE
fix(utils): verifyNep413Signature accepts the MultiPayload signature form

### DIFF
--- a/packages/utils/src/nep413.test.ts
+++ b/packages/utils/src/nep413.test.ts
@@ -11,6 +11,7 @@ import {
   privateKeyFromRandom,
   publicKeyFromPrivate,
   sha256,
+  toBase58,
 } from "./index.js";
 
 // Hand-rolled borsh serialization, written independently of @fastnear/borsh,
@@ -157,6 +158,20 @@ describe("signNep413Message / verifyNep413Signature", () => {
       verifyNep413Signature({
         publicKey: signed.publicKey,
         signature: bytesToBase64(signed.signature),
+        ...payload,
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts the curve-prefixed base58 form MultiPayloads carry", () => {
+    const privateKey = privateKeyFromRandom();
+    const payload = { message: "m", nonce: NONCE, recipient: "intents.near" };
+    const signed = signNep413Message(payload, privateKey);
+
+    expect(
+      verifyNep413Signature({
+        publicKey: signed.publicKey,
+        signature: `ed25519:${toBase58(signed.signature)}`,
         ...payload,
       }),
     ).toBe(true);

--- a/packages/utils/src/nep413.ts
+++ b/packages/utils/src/nep413.ts
@@ -9,7 +9,7 @@ import {
   signHash,
   type NearPublicKey,
 } from "./crypto.js";
-import { base64ToBytes } from "./misc.js";
+import { base64ToBytes, fromBase58 } from "./misc.js";
 
 /**
  * NEP-413 off-chain message signing.
@@ -44,9 +44,12 @@ function toNonceBytes(nonce: Uint8Array | ReadonlyArray<number>): Uint8Array {
 }
 
 function toSignatureBytes(signature: string | Uint8Array): Uint8Array {
-  return signature instanceof Uint8Array
-    ? signature
-    : base64ToBytes(signature);
+  if (signature instanceof Uint8Array) return signature;
+  // The NEP-413 MultiPayload format (e.g. intents.near) carries signatures
+  // as "<curve>:<base58>"; wallets return plain base64. Accept both.
+  const separator = signature.indexOf(":");
+  if (separator !== -1) return fromBase58(signature.slice(separator + 1));
+  return base64ToBytes(signature);
 }
 
 /** A NEP-413 payload as this module accepts it (nonce may be a plain array). */
@@ -99,7 +102,8 @@ export function signNep413Message(
 
 /**
  * Verify a NEP-413 signature (ed25519 or secp256k1) against its payload.
- * Accepts the base64 signature string wallets return, or raw bytes.
+ * Accepts the base64 signature string wallets return, the curve-prefixed
+ * base58 form MultiPayloads carry ("ed25519:<base58>"), or raw bytes.
  */
 export function verifyNep413Signature({
   publicKey,


### PR DESCRIPTION
Found while making the intents page's MultiPayload example cryptographically real: `verifyNep413Signature` accepts base64 (wallet responses) or raw bytes, but NOT the `ed25519:<base58>` form that MultiPayloads — including our own signers' output and the example on js.fastnear.com/intents — carry. An agent cross-feeding our own documented format got `Error: "signature" expected Uint8Array of length 64, got length=71`.

`toSignatureBytes` now detects the curve prefix and base58-decodes; base64 and raw-bytes paths unchanged. One new test; 417 pass; bundle budgets green.

Rides with 1.6.2 alongside #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6uCxbhXe3dfhtVqLZkGo5