### PR TITLE
fix(utils): accept human gas/deposit units in action mapping

### DIFF
--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -2,6 +2,7 @@ export * from "./crypto.js";
 export * from "./nep413.js";
 export * from "./transaction.js";
 export * from "./misc.js";
+export * from "./units.js";
 export * from "./storage.js";
 
 import { serialize, deserialize } from "@fastnear/borsh";

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -53,64 +53,9 @@ export function fromBase64(strVal: string) {
   }
 }
 
-const UNIT_DECIMALS: Record<string, number> = {
-  near: 24,
-  tgas: 12,
-  ggas: 9,
-  gas: 0,
-  yoctonear: 0,
-};
-
-/**
- * Scale a decimal string by `shift` decimal places using BigInt.
- * Positive shift multiplies (e.g. NEAR → yoctoNEAR), zero shift truncates decimals.
- */
-function scaleDecimal(amount: string, shift: number): string {
-  const [whole, frac = ""] = amount.split(".");
-  if (shift >= 0) {
-    // Pad fractional part to `shift` digits, then concatenate — this multiplies by 10^shift
-    const padded = frac.padEnd(shift, "0").slice(0, shift);
-    const extra = frac.length > shift ? frac.slice(shift) : "";
-    if (extra && BigInt(extra) !== 0n) {
-      throw new Error(`Precision loss: "${amount}" has more than ${shift} decimal places`);
-    }
-    return BigInt(whole + padded).toString();
-  }
-  // Negative shift: divide by 10^|shift| (shouldn't happen with current units)
-  const divisor = 10n ** BigInt(-shift);
-  const bigVal = BigInt(whole);
-  const intPart = bigVal / divisor;
-  const remainder = bigVal % divisor;
-  if (remainder === 0n) return intPart.toString();
-  const fracStr = remainder.toString().padStart(-shift, "0").replace(/0+$/, "");
-  return `${intPart}.${fracStr}`;
-}
-
-export function convertUnit(s: string | TemplateStringsArray, ...args: any[]): string {
-  // Reconstruct raw string from template literal
-  if (Array.isArray(s)) {
-    s = s.reduce((acc, part, i) => {
-      return acc + (args[i - 1] ?? "") + part;
-    });
-  }
-  // Convert from `100 NEAR` into yoctoNear
-  if (typeof s == "string") {
-    const match = s.match(/([0-9.,_]+)\s*([a-zA-Z]+)?/);
-    if (match) {
-      const amount = match[1].replace(/[_,]/g, "");
-      const unitPart = match[2];
-      if (unitPart) {
-        const decimals = UNIT_DECIMALS[unitPart.toLowerCase()];
-        if (decimals === undefined) throw new Error(`Unknown unit: ${unitPart}`);
-        return scaleDecimal(amount, decimals);
-      } else {
-        // No unit — truncate any decimals
-        return scaleDecimal(amount, 0);
-      }
-    }
-  }
-  return scaleDecimal(`${s}`, 0);
-}
+// NEAR unit math lives in the dependency-free ./units.js so it can be pulled
+// into size-sensitive bundles without dragging misc's storage/codec imports.
+export { convertUnit } from "./units.js";
 
 export function lsSet(key: string, value: any) {
   storage.set(key, value);

--- a/packages/utils/src/transaction.test.ts
+++ b/packages/utils/src/transaction.test.ts
@@ -186,6 +186,72 @@ describe("serializeSignedTransaction", () => {
   );
 });
 
+// ── mapAction: FunctionCall amount coercion ─────────────────────────
+
+describe("mapAction — FunctionCall gas/deposit units", () => {
+  it("accepts human unit strings the demo site and wallet path use", () => {
+    const mapped = mapAction({
+      type: "FunctionCall",
+      methodName: "buy_tokens",
+      args: {},
+      gas: "100 Tgas",
+      deposit: "0.01 NEAR",
+    }) as any;
+    expect(mapped.functionCall.gas).toBe(100_000_000_000_000n);
+    expect(mapped.functionCall.deposit).toBe(10_000_000_000_000_000_000_000n);
+  });
+
+  it("is a no-op on unit-less integer strings (idempotent with pre-converted values)", () => {
+    const mapped = mapAction({
+      type: "FunctionCall",
+      methodName: "draw",
+      args: {},
+      gas: "30000000000000",
+      deposit: "0",
+    }) as any;
+    expect(mapped.functionCall.gas).toBe(30_000_000_000_000n);
+    expect(mapped.functionCall.deposit).toBe(0n);
+  });
+
+  it("accepts bigint and number amounts unchanged", () => {
+    const mapped = mapAction({
+      type: "FunctionCall",
+      methodName: "m",
+      args: {},
+      gas: 30_000_000_000_000n,
+      deposit: 1,
+    }) as any;
+    expect(mapped.functionCall.gas).toBe(30_000_000_000_000n);
+    expect(mapped.functionCall.deposit).toBe(1n);
+  });
+
+  it("defaults gas to 300 Tgas and deposit to 0 when omitted", () => {
+    const mapped = mapAction({
+      type: "FunctionCall",
+      methodName: "m",
+      args: {},
+    }) as any;
+    expect(mapped.functionCall.gas).toBe(300_000_000_000_000n);
+    expect(mapped.functionCall.deposit).toBe(0n);
+  });
+
+  it("rejects an unknown unit with a clear message", () => {
+    expect(() =>
+      mapAction({
+        type: "FunctionCall",
+        methodName: "m",
+        args: {},
+        gas: "100 potato",
+      }),
+    ).toThrow(/Unknown unit/);
+  });
+
+  it("Transfer deposit also accepts NEAR units", () => {
+    const mapped = mapAction({ type: "Transfer", deposit: "1.5 NEAR" }) as any;
+    expect(mapped.transfer.deposit).toBe(1_500_000_000_000_000_000_000_000n);
+  });
+});
+
 // ── mapAction: Stake ────────────────────────────────────────────────
 
 describe("mapAction — Stake", () => {

--- a/packages/utils/src/transaction.ts
+++ b/packages/utils/src/transaction.ts
@@ -8,9 +8,30 @@ import {
   type NearPublicKey,
 } from "./crypto.js";
 import { base64ToBytes, fromBase58 } from "./misc.js";
+import { convertUnit } from "./units.js";
 import { getBorshSchema } from "@fastnear/borsh-schema";
 
 export type NearInteger = string | bigint | number;
+
+/**
+ * Coerce a NearInteger amount field (gas, deposit, stake, allowance) to bigint.
+ *
+ * String values may carry a human unit suffix — "100 Tgas", "0.01 NEAR" —
+ * which is exactly the shape the wallet path and the demo site's action
+ * config use. `convertUnit` scales those to a plain yocto/gas integer string
+ * (and is a no-op on unit-less digits), so local signing via `near.sendTx`
+ * accepts the same action shape the wallet path does instead of throwing a
+ * bare `BigInt` conversion error.
+ */
+function toNearAmount(
+  value: NearInteger | null | undefined,
+  fallback: NearInteger = 0,
+): bigint {
+  const resolved = value ?? fallback;
+  if (typeof resolved === "bigint") return resolved;
+  if (typeof resolved === "number") return BigInt(resolved);
+  return BigInt(convertUnit(resolved.trim()));
+}
 
 export interface NearCreateAccountAction {
   type: "CreateAccount";
@@ -212,15 +233,15 @@ export function mapAction(action: NearAction): object {
             action.argsBase64 !== null && action.argsBase64 !== undefined
               ? base64ToBytes(action.argsBase64)
               : new TextEncoder().encode(JSON.stringify(action.args ?? {})),
-          gas: BigInt(action.gas ?? "300000000000000"),
-          deposit: BigInt(action.deposit ?? "0"),
+          gas: toNearAmount(action.gas, "300000000000000"),
+          deposit: toNearAmount(action.deposit),
         },
       };
     }
     case "Transfer": {
       return {
         transfer: {
-          deposit: BigInt(action.deposit),
+          deposit: toNearAmount(action.deposit),
         },
       };
     }
@@ -228,7 +249,7 @@ export function mapAction(action: NearAction): object {
       assertNearValidatorPublicKey(action.publicKey);
       return {
         stake: {
-          stake: BigInt(action.stake),
+          stake: toNearAmount(action.stake),
           publicKey: mapPublicKey(action.publicKey),
         },
       };
@@ -262,7 +283,7 @@ export function mapAction(action: NearAction): object {
                 : {
                   functionCall: {
                     allowance: functionCall.allowance != null
-                      ? BigInt(functionCall.allowance)
+                      ? toNearAmount(functionCall.allowance)
                       : null,
                     receiverId: functionCall.receiverId,
                     methodNames: functionCall.methodNames ?? [],

--- a/packages/utils/src/units.ts
+++ b/packages/utils/src/units.ts
@@ -1,0 +1,62 @@
+// Pure NEAR unit math — no imports, so amount-parsing can be pulled into
+// size-sensitive bundles (transaction mapping, the sandboxed wallet
+// executors) without dragging in storage or codec dependencies.
+
+const UNIT_DECIMALS: Record<string, number> = {
+  near: 24,
+  tgas: 12,
+  ggas: 9,
+  gas: 0,
+  yoctonear: 0,
+};
+
+/**
+ * Scale a decimal string by `shift` decimal places using BigInt.
+ * Positive shift multiplies (e.g. NEAR → yoctoNEAR), zero shift truncates decimals.
+ */
+export function scaleDecimal(amount: string, shift: number): string {
+  const [whole, frac = ""] = amount.split(".");
+  if (shift >= 0) {
+    // Pad fractional part to `shift` digits, then concatenate — this multiplies by 10^shift
+    const padded = frac.padEnd(shift, "0").slice(0, shift);
+    const extra = frac.length > shift ? frac.slice(shift) : "";
+    if (extra && BigInt(extra) !== 0n) {
+      throw new Error(`Precision loss: "${amount}" has more than ${shift} decimal places`);
+    }
+    return BigInt(whole + padded).toString();
+  }
+  // Negative shift: divide by 10^|shift| (shouldn't happen with current units)
+  const divisor = 10n ** BigInt(-shift);
+  const bigVal = BigInt(whole);
+  const intPart = bigVal / divisor;
+  const remainder = bigVal % divisor;
+  if (remainder === 0n) return intPart.toString();
+  const fracStr = remainder.toString().padStart(-shift, "0").replace(/0+$/, "");
+  return `${intPart}.${fracStr}`;
+}
+
+export function convertUnit(s: string | TemplateStringsArray, ...args: any[]): string {
+  // Reconstruct raw string from template literal
+  if (Array.isArray(s)) {
+    s = s.reduce((acc, part, i) => {
+      return acc + (args[i - 1] ?? "") + part;
+    });
+  }
+  // Convert from `100 NEAR` into yoctoNear
+  if (typeof s == "string") {
+    const match = s.match(/([0-9.,_]+)\s*([a-zA-Z]+)?/);
+    if (match) {
+      const amount = match[1].replace(/[_,]/g, "");
+      const unitPart = match[2];
+      if (unitPart) {
+        const decimals = UNIT_DECIMALS[unitPart.toLowerCase()];
+        if (decimals === undefined) throw new Error(`Unknown unit: ${unitPart}`);
+        return scaleDecimal(amount, decimals);
+      } else {
+        // No unit — truncate any decimals
+        return scaleDecimal(amount, 0);
+      }
+    }
+  }
+  return scaleDecimal(`${s}`, 0);
+}

--- a/scripts/check-bundle-sizes.mjs
+++ b/scripts/check-bundle-sizes.mjs
@@ -18,8 +18,10 @@ const budgets = [
   { package: "api", baselineGzip: 49_371, maxGzipGrowth: 4 * 1024 - 1 },
   { package: "wallet", baselineGzip: 21_323 },
   // The timeout-aware Meteor bridge includes local Borsh/action binding and
-  // signature verification before accepting a wallet response.
-  { package: "wallet-adapter", baselineGzip: 41_529, maxGzipGrowth: 4 * 1024 - 1 },
+  // signature verification before accepting a wallet response; action mapping
+  // now also carries the shared NEAR unit coercion (convertUnit) so gas/deposit
+  // strings like "100 Tgas" map instead of throwing.
+  { package: "wallet-adapter", baselineGzip: 41_529, maxGzipGrowth: 5 * 1024 - 1 },
   { package: "ml-dsa-65", raw: 75 * 1024, gzip: 20 * 1024 },
   { package: "x402", raw: 256 * 1024, gzip: 64 * 1024 },
   // Typed fetch clients + NEP-413 payload assembly; no crypto in the


### PR DESCRIPTION
The loose end from the site review. `near.sendTx` local signing crashed with `SyntaxError: Cannot convert 100 Tgas to a BigInt` on the exact action shape the demo site (`public/index.js`) and the wallet path use — so an agent copy-pasting the site's action into a Node script hit a bare BigInt error. This bit the on-chain smoke on its first run.

## Fix
`mapAction` routes `gas`, `deposit`, `stake`, and `allowance` through `convertUnit` instead of raw `BigInt()`. `convertUnit` scales unit suffixes (`"100 Tgas"` → `100000000000000n`, `"0.01 NEAR"` → yocto) and is a no-op on plain integer strings, bigints, and numbers — so already-converted values stay idempotent (the site calls `convertUnit` itself before the wallet path; double-conversion verified safe).

## Bundle hygiene
Extracted the pure unit math into a **dependency-free `units.ts`** so it doesn't drag misc's `storage`/codec imports into the sandboxed wallet-executor bundle; `misc.ts` re-exports `convertUnit` so its public export path is unchanged. The Meteor bridge (wallet-adapter) picks up ~0.6 KiB gzip for the coercion — budget exception raised to 5 KiB with a comment. (Noted in passing: wallet-adapter was already within ~300 B of its prior ceiling — its baseline has drifted and may be worth re-baselining separately.)

## Verify
- 6 new mapAction tests (unit strings, idempotency, bigint/number, defaults, unknown-unit error, Transfer NEAR units); 424 total pass
- `mapAction({ gas: "100 Tgas" })` → `100000000000000n` against the built ESM
- build, check:agent, bundle budgets all green

Rides with the next publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6uCxbhXe3dfhtVqLZkGo5